### PR TITLE
Refactor some python and fix chrome/browser performance issues

### DIFF
--- a/acarshub-typescript/package-lock.json
+++ b/acarshub-typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acarshub-typescript",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "acarshub-typescript",
-      "version": "3.0.6",
+      "version": "3.0.7",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@airframes/acars-decoder": "^1.1.0",
@@ -27,7 +27,7 @@
         "socket.io-client": "4.4.1"
       },
       "devDependencies": {
-        "@babel/core": "^7.17.2",
+        "@babel/core": "^7.17.4",
         "@babel/preset-env": "^7.16.11",
         "@types/jquery": "^3.5.13",
         "@types/js-cookie": "^3.0.1",
@@ -48,7 +48,7 @@
         "ts-loader": "^9.2.6",
         "ts-node": "^10.5.0",
         "typescript": "^4.5.5",
-        "webpack": "^5.68.0",
+        "webpack": "^5.69.0",
         "webpack-cli": "^4.9.2",
         "webpack-dev-server": "^4.7.4",
         "webpack-image-loader": "^0.1.2"
@@ -72,13 +72,12 @@
       "integrity": "sha512-LMy+vDDcQR48EZdEx5wRX1q/sEl6NdGuHXPnfeL8ixkwCOSZ2qnIyIZmcCbdX0MeRqHhAcHmX+haCbrS8Run+A=="
     },
     "node_modules/@ampproject/remapping": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.0.2.tgz",
-      "integrity": "sha512-sE8Gx+qSDMLoJvb3QarJJlDQK7SSY4rK3hxp4XsiANeFOmjU46ZI7Y9adAQRJrmbz8zbtZkp3mJTT+rGxtF0XA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.1.tgz",
+      "integrity": "sha512-Aolwjd7HSC2PyY0fDj/wA/EimQT4HfEnFYNp5s9CQlrdhyvWTtvZ5YzrUPu6R6/1jKiUlxu8bUhkdSnKHNAHMA==",
       "dev": true,
       "dependencies": {
-        "@jridgewell/trace-mapping": "^0.2.2",
-        "sourcemap-codec": "1.4.8"
+        "@jridgewell/trace-mapping": "^0.3.0"
       },
       "engines": {
         "node": ">=6.0.0"
@@ -106,20 +105,20 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.17.2",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.2.tgz",
-      "integrity": "sha512-R3VH5G42VSDolRHyUO4V2cfag8WHcZyxdq5Z/m8Xyb92lW/Erm/6kM+XtRFGf3Mulre3mveni2NHfEUws8wSvw==",
+      "version": "7.17.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.4.tgz",
+      "integrity": "sha512-R9x5r4t4+hBqZTmioSnkrW+I6NmbojwjGT8p4G2Gw1thWbXIHGDnmGdLdFw0/7ljucdIrNRp7Npgb4CyBYzzJg==",
       "dev": true,
       "dependencies": {
-        "@ampproject/remapping": "^2.0.0",
+        "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.17.0",
+        "@babel/generator": "^7.17.3",
         "@babel/helper-compilation-targets": "^7.16.7",
         "@babel/helper-module-transforms": "^7.16.7",
         "@babel/helpers": "^7.17.2",
-        "@babel/parser": "^7.17.0",
+        "@babel/parser": "^7.17.3",
         "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.17.0",
+        "@babel/traverse": "^7.17.3",
         "@babel/types": "^7.17.0",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
@@ -136,9 +135,9 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.0.tgz",
-      "integrity": "sha512-I3Omiv6FGOC29dtlZhkfXO6pgkmukJSlT26QjVvS1DGZe/NzSVCPG41X0tS21oZkJYlovfj9qDWgKP+Cn4bXxw==",
+      "version": "7.17.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.3.tgz",
+      "integrity": "sha512-+R6Dctil/MgUsZsZAkYgK+ADNSZzJRRy0TvY65T71z/CR854xHQ1EweBYXdfT+HNeN7w0cSJJEzgxZMv40pxsg==",
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.17.0",
@@ -502,9 +501,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.0.tgz",
-      "integrity": "sha512-VKXSCQx5D8S04ej+Dqsr1CzYvvWgf20jIw2D+YhQCrIlr2UZGaDds23Y0xg75/skOxpLCRpUZvk/1EAVkGoDOw==",
+      "version": "7.17.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.3.tgz",
+      "integrity": "sha512-7yJPvPV+ESz2IUTPbOL+YkIGyCqOyNIzdguKQuJGnH7bg1WTIifuM21YqokFt/THWh1AkCRn9IgoykTRCBVpzA==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1607,18 +1606,18 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.0.tgz",
-      "integrity": "sha512-fpFIXvqD6kC7c7PUNnZ0Z8cQXlarCLtCUpt2S1Dx7PjoRtCFffvOkHHSom+m5HIxMZn5bIBVb71lhabcmjEsqg==",
+      "version": "7.17.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
+      "integrity": "sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.17.0",
+        "@babel/generator": "^7.17.3",
         "@babel/helper-environment-visitor": "^7.16.7",
         "@babel/helper-function-name": "^7.16.7",
         "@babel/helper-hoist-variables": "^7.16.7",
         "@babel/helper-split-export-declaration": "^7.16.7",
-        "@babel/parser": "^7.17.0",
+        "@babel/parser": "^7.17.3",
         "@babel/types": "^7.17.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
@@ -2208,22 +2207,28 @@
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.4.tgz",
-      "integrity": "sha512-cz8HFjOFfUBtvN+NXYSFMHYRdxZMaEl0XypVrhzxBgadKIXhIkRd8aMeHhmF56Sl7SuS8OnUpQ73/k9LE4VnLg==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
+      "integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==",
       "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz",
+      "integrity": "sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==",
+      "dev": true
+    },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.2.6.tgz",
-      "integrity": "sha512-rVJf5dSMEBxnDEwtAT5x8+p6tZ+xU6Ocm+cR1MYL2gMsRi4MMzVf9Pvq6JaxIsEeKAyYmo2U+yPQN4QfdTfFnA==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.4.tgz",
+      "integrity": "sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==",
       "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
-        "sourcemap-codec": "1.4.8"
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -2357,9 +2362,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "0.0.50",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
-      "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw=="
+      "version": "0.0.51",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
+      "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ=="
     },
     "node_modules/@types/express": {
       "version": "4.17.13",
@@ -4430,9 +4435,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz",
-      "integrity": "sha512-EGAbGvH7j7Xt2nc0E7D99La1OiEs8LnyimkRgwExpUMScN6O+3x9tIWs7PLQZVNx4YD+00skHXPXi1yQHpAmZA==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.0.tgz",
+      "integrity": "sha512-weDYmzbBygL7HzGGS26M3hGQx68vehdEg6VUmqSOaFzXExFqlnKuSvsEJCVGQHScS8CQMbrAqftT+AzzHNt/YA==",
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
@@ -8508,12 +8513,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "dev": true
-    },
     "node_modules/spdy": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.2.tgz",
@@ -9412,12 +9411,12 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.68.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.68.0.tgz",
-      "integrity": "sha512-zUcqaUO0772UuuW2bzaES2Zjlm/y3kRBQDVFVCge+s2Y8mwuUTdperGaAv65/NtRL/1zanpSJOq/MD8u61vo6g==",
+      "version": "5.69.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.69.0.tgz",
+      "integrity": "sha512-E5Fqu89Gu8fR6vejRqu26h8ld/k6/dCVbeGUcuZjc+goQHDfCPU9rER71JmdtBYGmci7Ec2aFEATQ2IVXKy2wg==",
       "dependencies": {
-        "@types/eslint-scope": "^3.7.0",
-        "@types/estree": "^0.0.50",
+        "@types/eslint-scope": "^3.7.3",
+        "@types/estree": "^0.0.51",
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/wasm-edit": "1.11.1",
         "@webassemblyjs/wasm-parser": "1.11.1",
@@ -9425,7 +9424,7 @@
         "acorn-import-assertions": "^1.7.6",
         "browserslist": "^4.14.5",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.8.3",
+        "enhanced-resolve": "^5.9.0",
         "es-module-lexer": "^0.9.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
@@ -10163,13 +10162,12 @@
       }
     },
     "@ampproject/remapping": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.0.2.tgz",
-      "integrity": "sha512-sE8Gx+qSDMLoJvb3QarJJlDQK7SSY4rK3hxp4XsiANeFOmjU46ZI7Y9adAQRJrmbz8zbtZkp3mJTT+rGxtF0XA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.1.tgz",
+      "integrity": "sha512-Aolwjd7HSC2PyY0fDj/wA/EimQT4HfEnFYNp5s9CQlrdhyvWTtvZ5YzrUPu6R6/1jKiUlxu8bUhkdSnKHNAHMA==",
       "dev": true,
       "requires": {
-        "@jridgewell/trace-mapping": "^0.2.2",
-        "sourcemap-codec": "1.4.8"
+        "@jridgewell/trace-mapping": "^0.3.0"
       }
     },
     "@babel/code-frame": {
@@ -10188,20 +10186,20 @@
       "dev": true
     },
     "@babel/core": {
-      "version": "7.17.2",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.2.tgz",
-      "integrity": "sha512-R3VH5G42VSDolRHyUO4V2cfag8WHcZyxdq5Z/m8Xyb92lW/Erm/6kM+XtRFGf3Mulre3mveni2NHfEUws8wSvw==",
+      "version": "7.17.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.4.tgz",
+      "integrity": "sha512-R9x5r4t4+hBqZTmioSnkrW+I6NmbojwjGT8p4G2Gw1thWbXIHGDnmGdLdFw0/7ljucdIrNRp7Npgb4CyBYzzJg==",
       "dev": true,
       "requires": {
-        "@ampproject/remapping": "^2.0.0",
+        "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.17.0",
+        "@babel/generator": "^7.17.3",
         "@babel/helper-compilation-targets": "^7.16.7",
         "@babel/helper-module-transforms": "^7.16.7",
         "@babel/helpers": "^7.17.2",
-        "@babel/parser": "^7.17.0",
+        "@babel/parser": "^7.17.3",
         "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.17.0",
+        "@babel/traverse": "^7.17.3",
         "@babel/types": "^7.17.0",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
@@ -10211,9 +10209,9 @@
       }
     },
     "@babel/generator": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.0.tgz",
-      "integrity": "sha512-I3Omiv6FGOC29dtlZhkfXO6pgkmukJSlT26QjVvS1DGZe/NzSVCPG41X0tS21oZkJYlovfj9qDWgKP+Cn4bXxw==",
+      "version": "7.17.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.3.tgz",
+      "integrity": "sha512-+R6Dctil/MgUsZsZAkYgK+ADNSZzJRRy0TvY65T71z/CR854xHQ1EweBYXdfT+HNeN7w0cSJJEzgxZMv40pxsg==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.17.0",
@@ -10487,9 +10485,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.0.tgz",
-      "integrity": "sha512-VKXSCQx5D8S04ej+Dqsr1CzYvvWgf20jIw2D+YhQCrIlr2UZGaDds23Y0xg75/skOxpLCRpUZvk/1EAVkGoDOw==",
+      "version": "7.17.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.3.tgz",
+      "integrity": "sha512-7yJPvPV+ESz2IUTPbOL+YkIGyCqOyNIzdguKQuJGnH7bg1WTIifuM21YqokFt/THWh1AkCRn9IgoykTRCBVpzA==",
       "dev": true
     },
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
@@ -11226,18 +11224,18 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.0.tgz",
-      "integrity": "sha512-fpFIXvqD6kC7c7PUNnZ0Z8cQXlarCLtCUpt2S1Dx7PjoRtCFffvOkHHSom+m5HIxMZn5bIBVb71lhabcmjEsqg==",
+      "version": "7.17.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
+      "integrity": "sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.17.0",
+        "@babel/generator": "^7.17.3",
         "@babel/helper-environment-visitor": "^7.16.7",
         "@babel/helper-function-name": "^7.16.7",
         "@babel/helper-hoist-variables": "^7.16.7",
         "@babel/helper-split-export-declaration": "^7.16.7",
-        "@babel/parser": "^7.17.0",
+        "@babel/parser": "^7.17.3",
         "@babel/types": "^7.17.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
@@ -11692,19 +11690,25 @@
       }
     },
     "@jridgewell/resolve-uri": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.4.tgz",
-      "integrity": "sha512-cz8HFjOFfUBtvN+NXYSFMHYRdxZMaEl0XypVrhzxBgadKIXhIkRd8aMeHhmF56Sl7SuS8OnUpQ73/k9LE4VnLg==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
+      "integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==",
+      "dev": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz",
+      "integrity": "sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==",
       "dev": true
     },
     "@jridgewell/trace-mapping": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.2.6.tgz",
-      "integrity": "sha512-rVJf5dSMEBxnDEwtAT5x8+p6tZ+xU6Ocm+cR1MYL2gMsRi4MMzVf9Pvq6JaxIsEeKAyYmo2U+yPQN4QfdTfFnA==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.4.tgz",
+      "integrity": "sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==",
       "dev": true,
       "requires": {
         "@jridgewell/resolve-uri": "^3.0.3",
-        "sourcemap-codec": "1.4.8"
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "@nodelib/fs.scandir": {
@@ -11825,9 +11829,9 @@
       }
     },
     "@types/estree": {
-      "version": "0.0.50",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
-      "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw=="
+      "version": "0.0.51",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
+      "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ=="
     },
     "@types/express": {
       "version": "4.17.13",
@@ -13499,9 +13503,9 @@
       }
     },
     "enhanced-resolve": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz",
-      "integrity": "sha512-EGAbGvH7j7Xt2nc0E7D99La1OiEs8LnyimkRgwExpUMScN6O+3x9tIWs7PLQZVNx4YD+00skHXPXi1yQHpAmZA==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.0.tgz",
+      "integrity": "sha512-weDYmzbBygL7HzGGS26M3hGQx68vehdEg6VUmqSOaFzXExFqlnKuSvsEJCVGQHScS8CQMbrAqftT+AzzHNt/YA==",
       "requires": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
@@ -16660,12 +16664,6 @@
         }
       }
     },
-    "sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "dev": true
-    },
     "spdy": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.2.tgz",
@@ -17334,12 +17332,12 @@
       }
     },
     "webpack": {
-      "version": "5.68.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.68.0.tgz",
-      "integrity": "sha512-zUcqaUO0772UuuW2bzaES2Zjlm/y3kRBQDVFVCge+s2Y8mwuUTdperGaAv65/NtRL/1zanpSJOq/MD8u61vo6g==",
+      "version": "5.69.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.69.0.tgz",
+      "integrity": "sha512-E5Fqu89Gu8fR6vejRqu26h8ld/k6/dCVbeGUcuZjc+goQHDfCPU9rER71JmdtBYGmci7Ec2aFEATQ2IVXKy2wg==",
       "requires": {
-        "@types/eslint-scope": "^3.7.0",
-        "@types/estree": "^0.0.50",
+        "@types/eslint-scope": "^3.7.3",
+        "@types/estree": "^0.0.51",
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/wasm-edit": "1.11.1",
         "@webassemblyjs/wasm-parser": "1.11.1",
@@ -17347,7 +17345,7 @@
         "acorn-import-assertions": "^1.7.6",
         "browserslist": "^4.14.5",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.8.3",
+        "enhanced-resolve": "^5.9.0",
         "es-module-lexer": "^0.9.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",

--- a/acarshub-typescript/package.json
+++ b/acarshub-typescript/package.json
@@ -1,9 +1,9 @@
 {
   "name": "acarshub-typescript",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "Web front end for the docker-acarshub project",
   "main": "index.js",
-  "repository": "https://github.com/fredclausen/docker-acarshub",
+  "repository": "https://github.com/sdr-enthusiasts/docker-acarshub",
   "scripts": {
     "build": "webpack --mode production",
     "build-dev": "webpack --mode development",
@@ -13,7 +13,7 @@
   "author": "Fred Clausen",
   "license": "GPL-3.0-only",
   "devDependencies": {
-    "@babel/core": "^7.17.2",
+    "@babel/core": "^7.17.4",
     "@babel/preset-env": "^7.16.11",
     "@types/jquery": "^3.5.13",
     "@types/js-cookie": "^3.0.1",
@@ -34,7 +34,7 @@
     "ts-loader": "^9.2.6",
     "ts-node": "^10.5.0",
     "typescript": "^4.5.5",
-    "webpack": "^5.68.0",
+    "webpack": "^5.69.0",
     "webpack-cli": "^4.9.2",
     "webpack-dev-server": "^4.7.4",
     "webpack-image-loader": "^0.1.2"

--- a/acarshub-typescript/src/helpers/html_functions.ts
+++ b/acarshub-typescript/src/helpers/html_functions.ts
@@ -21,7 +21,7 @@ export let html_functions = {
     return `<div class="acarshub-message-container" id="${uid}">`;
   },
   end_message() {
-    return "</div>";
+    return "</div></div>";
   },
 
   start_message_tabs: function (): string {

--- a/acarshub-typescript/src/helpers/html_generator.ts
+++ b/acarshub-typescript/src/helpers/html_generator.ts
@@ -51,6 +51,7 @@ export function display_message_group(
   let array_index_tab: string = "0";
   const message_uid =
     "acarsmsg_" + msg_to_process[msg_to_process.length - 1].uid;
+  msgs_string += `<div id="${message_uid}_container" class="acars_message_container">`;
   msgs_string += "<br>";
   msgs_string += `<div class="acarshub-message-group" id="${message_uid}">`;
   if (live_page) {

--- a/acarshub-typescript/src/index.ts
+++ b/acarshub-typescript/src/index.ts
@@ -81,6 +81,22 @@ let adsb_request_options = {
   method: "GET",
 } as RequestInit;
 
+// @ts-expect-error
+var hidden, visibilityChange;
+if (typeof document.hidden !== "undefined") {
+  // Opera 12.10 and Firefox 18 and later support
+  hidden = "hidden";
+  visibilityChange = "visibilitychange";
+} //@ts-ignore
+else if (typeof document.msHidden !== "undefined") {
+  hidden = "msHidden";
+  visibilityChange = "msvisibilitychange";
+} //@ts-ignore
+else if (typeof document.webkitHidden !== "undefined") {
+  hidden = "webkitHidden";
+  visibilityChange = "webkitvisibilitychange";
+}
+
 const pages: string[] = [
   "/", // index/live messages
   "/search", // search page
@@ -361,6 +377,16 @@ $((): void => {
   setInterval(function () {
     stats_page.updatePage();
   }, 60000);
+
+  // @ts-expect-error
+  document.addEventListener(
+    visibilityChange,
+    () => {
+      // @ts-expect-error
+      toggle_pages(document[hidden]);
+    },
+    false
+  );
 });
 
 export function get_window_size(): window_size {
@@ -407,46 +433,46 @@ function update_url(): void {
   menu.set_about_page_urls(index_acars_path, index_acars_url);
 }
 
-function toggle_pages(): void {
+function toggle_pages(is_backgrounded = false): void {
   index_acars_page =
     "/" + document.location.pathname.replace(index_acars_path, "");
   live_map_page.plane_message_modal.close();
   for (let page in pages) {
     if (pages[page] === "/" && index_acars_page === pages[page]) {
       $("#live_messages_link").addClass("invert_a");
-      live_messages_page.live_message_active(true);
+      live_messages_page.live_message_active(!is_backgrounded);
     } else if (pages[page] === "/") {
       $("#live_messages_link").removeClass("invert_a");
       live_messages_page.live_message_active();
     } else if (pages[page] === "/search" && index_acars_page === pages[page]) {
       $("#search_link").addClass("invert_a");
-      search_page.search_active(true);
+      search_page.search_active(!is_backgrounded);
     } else if (pages[page] === "/search") {
       $("#search_link").removeClass("invert_a");
       search_page.search_active();
     } else if (pages[page] === "/stats" && index_acars_page === pages[page]) {
       $("#stats_link").addClass("invert_a");
-      stats_page.stats_active(true);
+      stats_page.stats_active(!is_backgrounded);
     } else if (pages[page] === "/stats") {
       $("#stats_link").removeClass("invert_a");
       stats_page.stats_active();
     } else if (pages[page] === "/about" && index_acars_page === pages[page]) {
-      about.about_active(true);
+      about.about_active(!is_backgrounded);
     } else if (pages[page] === "/about") {
       about.about_active();
     } else if (pages[page] === "/status" && index_acars_page === pages[page]) {
-      status.status_active(true);
+      status.status_active(!is_backgrounded);
     } else if (pages[page] === "/status") {
       status.status_active();
     } else if (pages[page] === "/alerts" && index_acars_page === pages[page]) {
       $("#alerts_link").addClass("invert_a");
-      alerts_page.alert_active(true);
+      alerts_page.alert_active(!is_backgrounded);
     } else if (pages[page] === "/alerts") {
       $("#alerts_link").removeClass("invert_a");
       alerts_page.alert_active();
     } else if (pages[page] === "/adsb" && index_acars_page === pages[page]) {
       $("#live_map_link").addClass("invert_a");
-      live_map_page.live_map_active(true, {
+      live_map_page.live_map_active(!is_backgrounded, {
         width: old_window_width,
         height: old_window_height,
       } as window_size);

--- a/acarshub-typescript/src/index.ts
+++ b/acarshub-typescript/src/index.ts
@@ -378,8 +378,8 @@ $((): void => {
     stats_page.updatePage();
   }, 60000);
 
-  // @ts-expect-error
   document.addEventListener(
+    // @ts-expect-error
     visibilityChange,
     () => {
       // @ts-expect-error

--- a/rootfs/webapp/acarshub.py
+++ b/rootfs/webapp/acarshub.py
@@ -31,6 +31,9 @@ from flask_socketio import SocketIO  # noqa: E402
 from flask import Flask, render_template, request, redirect, url_for  # noqa: E402
 from threading import Thread, Event  # noqa: E402
 from collections import deque  # noqa: E402
+import json  # noqa: E402
+import socket  # noqa: E402
+import time  # noqa: E402
 
 app = Flask(__name__)
 # Make the browser not cache files if running in dev mode
@@ -79,13 +82,13 @@ thread_database_stop_event = Event()
 que_messages = deque(maxlen=15)
 que_database = deque(maxlen=15)
 
-messages_recent = []  # list to store most recent msgs
+list_of_recent_messages = []  # list to store most recent msgs
 
 # counters for messages
 # will be reset once written to RRD
-vdlm_messages = 0
-acars_messages = 0
-error_messages = 0
+vdlm_messages_last_minute = 0
+acars_messages_last_minute = 0
+error_messages_last_minute = 0
 
 # all namespaces
 
@@ -99,12 +102,8 @@ vdlm2_feeder_stop_event = Event()
 
 
 def vdlm_feeder():
-    import socket
-    import time
-    import json
-
-    airframes = (socket.gethostbyname("feed.acars.io"), 5555)
-    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    airframes_host = (socket.gethostbyname("feed.acars.io"), 5555)
+    airframes_vdlm_feed_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     while not vdlm2_feeder_stop_event.isSet():
         time.sleep(1)
 
@@ -113,7 +112,14 @@ def vdlm_feeder():
             msg = que_vdlm2_feed.popleft()
 
             try:
-                sock.sendto(json.dumps(msg, separators=(",", ":")).encode(), airframes)
+                airframes_vdlm_feed_socket.sendto(
+                    json.dumps(msg, separators=(",", ":")).encode(), airframes_host
+                )
+            except ValueError as e:
+                acarshub_logging.log(f"JSON Error: {e}", "vdlm_python_feeder", 1)
+                acarshub_logging.log(f"JSON Error: {msg}", "vdlm_python_feeder", 1)
+                acarshub_logging.log("Skipping Message", "vdlm_python_feeder", 1)
+                acarshub_logging.traceback(e, "vdlm_python_feeder")
             except Exception as e:
                 acarshub_logging.acars_traceback(e, "vdlm_python_feeder")
                 que_vdlm2_feed.appendleft(msg)
@@ -124,16 +130,18 @@ def vdlm_feeder():
 
 
 def update_rrd_db():
-    global vdlm_messages
-    global acars_messages
-    global error_messages
+    global vdlm_messages_last_minute
+    global acars_messages_last_minute
+    global error_messages_last_minute
 
     acarshub_rrd_database.update_db(
-        vdlm=vdlm_messages, acars=acars_messages, error=error_messages
+        vdlm=vdlm_messages_last_minute,
+        acars=acars_messages_last_minute,
+        error=error_messages_last_minute,
     )
-    vdlm_messages = 0
-    acars_messages = 0
-    error_messages = 0
+    vdlm_messages_last_minute = 0
+    acars_messages_last_minute = 0
+    error_messages_last_minute = 0
 
 
 def htmlListener():
@@ -148,16 +156,16 @@ def htmlListener():
 
         while len(que_messages) != 0:
             message_source, json_message_initial = que_messages.popleft()
-            json_message = copy.deepcopy(
+            message_as_json = copy.deepcopy(
                 json_message_initial
             )  # creating a copy so that our changes below aren't made to the parent object
             # Send output via socketio
-            json_message.update(
+            message_as_json.update(
                 {"message_type": message_source}
             )  # add in the message_type key because the parent object didn't have it
-            json_message = acarshub_helpers.update_keys(json_message)
+            message_as_json = acarshub_helpers.update_keys(message_as_json)
 
-            socketio.emit("acars_msg", {"msghtml": json_message}, namespace="/main")
+            socketio.emit("acars_msg", {"msghtml": message_as_json}, namespace="/main")
 
     acarshub_logging.log("Exiting HTML Listener thread", "htmlListener", level=5)
 
@@ -199,9 +207,9 @@ def database_listener():
 
         while len(que_database) != 0:
             sys.stdout.flush()
-            t, m = que_database.pop()
+            message_type, message_as_json = que_database.pop()
             acarshub_helpers.acarshub_database.add_message_from_json(
-                message_type=t, message_from_json=m
+                message_type=message_type, message_from_json=message_as_json
             )
         else:
             pass
@@ -213,12 +221,12 @@ def message_listener(message_type=None, ip="127.0.0.1", port=None):
     import json
     import sys
 
-    global error_messages
+    global error_messages_last_minute
 
     if message_type == "VDLM2":
-        global vdlm_messages
+        global vdlm_messages_last_minute
     elif message_type == "ACARS":
-        global acars_messages
+        global acars_messages_last_minute
 
     disconnected = True
 
@@ -318,25 +326,36 @@ def message_listener(message_type=None, ip="127.0.0.1", port=None):
                         for j in split_json:
                             if len(j) > 1:
                                 message_json.append(json.loads(j + "}\n"))
-
+                except ValueError as e:
+                    acarshub_logging.log(
+                        f"JSON Error: {e}", f"{message_type.lower()}Generator", 1
+                    )
+                    acarshub_logging.log(
+                        f"JSON Error: {j}", f"{message_type.lower()}Generator", 1
+                    )
+                    acarshub_logging.log(
+                        "Skipping Message", f"{message_type.lower()}Generator", 1
+                    )
+                    acarshub_logging.traceback(e, f"{message_type.lower()}Generator")
                 except Exception as e:
                     acarshub_logging.log(
-                        f"Error with JSON input {repr(data)} .\n{e}",
+                        f"Unknown Error with JSON input: {e}",
                         f"{message_type.lower()}Generator",
-                        level=3,
+                        level=1,
                     )
+                    acarshub_logging.traceback(e, f"{message_type.lower()}Generator")
                 finally:
                     for j in message_json:
                         if message_type == "VDLM2":
-                            vdlm_messages += 1
+                            vdlm_messages_last_minute += 1
                             que_type = "VDL-M2"
                         elif message_type == "ACARS":
-                            acars_messages += 1
+                            acars_messages_last_minute += 1
                             que_type = "ACARS"
 
                         if "error" in j:
                             if j["error"] > 0:
-                                error_messages += j["error"]
+                                error_messages_last_minute += j["error"]
 
                         que_messages.append(
                             (que_type, acars_formatter.format_acars_message(j))
@@ -351,13 +370,15 @@ def message_listener(message_type=None, ip="127.0.0.1", port=None):
                             que_vdlm2_feed.append(
                                 acars_formatter.format_acars_message(j)
                             )
-                        if len(messages_recent) >= 150:  # Keep the que size down
-                            del messages_recent[0]
+                        if (
+                            len(list_of_recent_messages) >= 150
+                        ):  # Keep the que size down
+                            del list_of_recent_messages[0]
 
                         if not acarshub_configuration.QUIET_MESSAGES:
                             print(f"MESSAGE:{message_type.lower()}Generator: {j}")
 
-                        messages_recent.append(
+                        list_of_recent_messages.append(
                             (que_type, acars_formatter.format_acars_message(j))
                         )  # add to recent message que for anyone fresh loading the page
 
@@ -453,7 +474,7 @@ def init_listeners(special_message=""):
 
 
 def init():
-    global messages_recent
+    global list_of_recent_messages
     # grab recent messages from db and fill the most recent array
     # then turn on the listeners
     acarshub_logging.log("Grabbing most recent messages from database", "init")
@@ -475,7 +496,9 @@ def init():
         for item in results:
             json_message = item
             try:
-                messages_recent.insert(0, [json_message["message_type"], json_message])
+                list_of_recent_messages.insert(
+                    0, [json_message["message_type"], json_message]
+                )
             except Exception as e:
                 acarshub_logging.log(
                     f"Startup Error adding message to recent messages {e}", "init"
@@ -613,8 +636,8 @@ def main_connect():
         acarshub_logging.traceback(e, "webapp")
 
     msg_index = 1
-    for msg_type, json_message_orig in messages_recent:
-        if msg_index == len(messages_recent):
+    for msg_type, json_message_orig in list_of_recent_messages:
+        if msg_index == len(list_of_recent_messages):
             recent_options["done_loading"] = True
         msg_index += 1
         json_message = copy.deepcopy(json_message_orig)

--- a/rootfs/webapp/acarshub_configuration.py
+++ b/rootfs/webapp/acarshub_configuration.py
@@ -20,6 +20,7 @@
 import os
 import requests
 import acarshub_logging
+from acarshub_logging import LOG_LEVEL
 
 # debug levels
 
@@ -137,7 +138,7 @@ if (
             acarshub_logging.log(
                 f"ADSB URL ({ADSB_URL}) appears to be malformed. Disabling ADSB",
                 "init",
-                level=1,
+                level=LOG_LEVEL["ERROR"],
             )
     if os.getenv("ADSB_LON", default=False):
         ADSB_LON = float(os.getenv("ADSB_LON"))
@@ -196,10 +197,14 @@ def check_github_version():
             CURRENT_ACARS_HUB_BUILD != ACARSHUB_BUILD
             and ACARSHUB_BUILD < CURRENT_ACARS_HUB_BUILD
         ):
-            acarshub_logging.log("Update found", "version-checker", level=3)
+            acarshub_logging.log(
+                "Update found", "version-checker", level=LOG_LEVEL["WARNING"]
+            )
             IS_UPDATE_AVAILABLE = True
         else:
-            acarshub_logging.log("No update found", "version-checker", level=5)
+            acarshub_logging.log(
+                "No update found", "version-checker", level=LOG_LEVEL["DEBUG"]
+            )
             IS_UPDATE_AVAILABLE = False
 
 

--- a/rootfs/webapp/acarshub_database.py
+++ b/rootfs/webapp/acarshub_database.py
@@ -33,6 +33,7 @@ import json
 import datetime
 import acarshub_configuration
 import acarshub_logging
+from acarshub_logging import LOG_LEVEL
 import re
 import os
 
@@ -113,7 +114,9 @@ for item in iata_override:
         overrides[override_splits[0]] = (override_splits[1], override_splits[2])
     else:
         acarshub_logging.log(
-            f"Error adding in {item} to IATA overrides", "database", level=3
+            f"Error adding in {item} to IATA overrides",
+            "database",
+            level=LOG_LEVEL["WARNING"],
         )
 
 # Class for storing the count of messages received on each frequency
@@ -265,7 +268,9 @@ inspector = Inspector.from_engine(database)
 if "messages_fts" not in inspector.get_table_names():
     import sys
 
-    acarshub_logging.log("Missing FTS TABLE! Aborting!", "database", level=1)
+    acarshub_logging.log(
+        "Missing FTS TABLE! Aborting!", "database", level=LOG_LEVEL["ERROR"]
+    )
     sys.exit(1)
 
 # messages_idx = Table(
@@ -466,14 +471,22 @@ def create_db_safe_params(message_from_json):
         # https://github.com/TLeconte/acarsdec/commit/b2d0a4c27c6092a1c38943da48319a3406db74f2
         # do we need to do anything here for reassembled messages?
         elif index == "assstat":
-            acarshub_logging.log(f"assstat key: {index}: {value}", "database", level=5)
-            acarshub_logging.log(message_from_json, "database", level=5)
+            acarshub_logging.log(
+                f"assstat key: {index}: {value}", "database", level=LOG_LEVEL["DEBUG"]
+            )
+            acarshub_logging.log(
+                message_from_json, "database", level=LOG_LEVEL["DEBUG"]
+            )
         # We have a key that we aren't saving the database. Log it
         else:
             acarshub_logging.log(
-                f"Unidenitied key: {index}: {value}", "database", level=5
+                f"Unidenitied key: {index}: {value}",
+                "database",
+                level=LOG_LEVEL["DEBUG"],
             )
-            acarshub_logging.log(message_from_json, "database", level=5)
+            acarshub_logging.log(
+                message_from_json, "database", level=LOG_LEVEL["DEBUG"]
+            )
 
     return params
 
@@ -608,7 +621,9 @@ def database_search(search_term, page=0):
 
     try:
         acarshub_logging.log(
-            f"[database] Searching database for {search_term}", "database", level=5
+            f"[database] Searching database for {search_term}",
+            "database",
+            level=LOG_LEVEL["DEBUG"],
         )
         match_string = ""
 

--- a/rootfs/webapp/acarshub_helpers.py
+++ b/rootfs/webapp/acarshub_helpers.py
@@ -21,6 +21,7 @@ import subprocess
 import acarshub_database
 import time
 import acarshub_logging
+from acarshub_logging import LOG_LEVEL
 
 start_time = time.time()
 
@@ -111,9 +112,9 @@ def update_keys(json_message):
             acarshub_logging.log(
                 f"Unable to convert icao to hex: {json_message['icao']}",
                 "update_keys",
-                2,
+                LOG_LEVEL["WARNING"],
             )
-            acarshub_logging.traceback(e, "update_keys")
+            acarshub_logging.acars_traceback(e, "update_keys")
 
     if has_specified_key(json_message, "flight") and has_specified_key(
         json_message, "icao_hex"
@@ -452,8 +453,8 @@ def service_check():
                     )
 
         except Exception as e:
-            acarshub_logging.log(e, "service_check", level=1)
-            acarshub_logging.traceback(e)
+            acarshub_logging.log(e, "service_check", level=LOG_LEVEL["ERROR"])
+            acarshub_logging.acars_traceback(e)
 
 
 if os.getenv("LOCAL_TEST", default=False):

--- a/rootfs/webapp/acarshub_logging.py
+++ b/rootfs/webapp/acarshub_logging.py
@@ -27,6 +27,8 @@ import traceback
 
 MIN_LOG_LEVEL = 3
 
+LOG_LEVEL = {"ERROR": 1, "CRITICAL": 2, "WARNING": 3, "INFO": 4, "DEBUG": 5}
+
 
 def log(msg, source, level=4):
     # line length 20

--- a/rootfs/webapp/acarshub_rrd_database.py
+++ b/rootfs/webapp/acarshub_rrd_database.py
@@ -18,6 +18,7 @@
 
 import rrdtool
 import acarshub_logging
+from acarshub_logging import LOG_LEVEL
 import os
 
 
@@ -27,7 +28,9 @@ def update_db(vdlm=0, acars=0, error=0):
     try:
         rrdtool.update("/run/acars/acarshub.rrd", f"N:{acars}:{vdlm}:{total}:{error}")
         acarshub_logging.log(
-            f"rrdtool.update: N:{acars}:{vdlm}:{total}:{error}", "rrdtool", level=5
+            f"rrdtool.update: N:{acars}:{vdlm}:{total}:{error}",
+            "rrdtool",
+            level=LOG_LEVEL["DEBUG"],
         )
     except Exception as e:
         acarshub_logging.acars_traceback(e, "rrdtool")

--- a/version
+++ b/version
@@ -1,2 +1,2 @@
-v3.0.6 Build 1124
-v3.0.6Build1124
+v3.0.7 Build 1125
+v3.0.7Build1125


### PR DESCRIPTION
In chrome if a tab was backgrounded for more than 3-5 minutes it would stop processing messages and presumably hold them in a queue. Once the user brought the task to the foreground it would take forever to process and the page was unresponsive. Refreshing didn't do anything.

Additionally, the DOM tree for messages (which is overly complex, needs to be fixed) was being dumped and de-done every single time a message came in. CPU usage is much, much too high and chrome in particular doesn't seem to like that.

This fix attempts to fix the problem by doing the following:

* Change limit of 50 message groups displayed on the Live Message page to 20 to reduce the total amount of DOM elements
* When a message comes in only change the part of the DOM tree that was affected. IE, if a message is matched delete that message group from the DOM and promote it back to the top. If a message is new, prepend it to the top of the tree. To expire old messages check the number of div elements in the #log div and remove last child if more than the alloted number.
* Handle being backgrounded by telling all pages to stop their update cycles by toggling everything "off". New messages should be processed, still, but the DOM is never walked.