### PR TITLE
make the socat | ncat pipe more reliable

### DIFF
--- a/rootfs/etc/services.d/acars_server/run
+++ b/rootfs/etc/services.d/acars_server/run
@@ -15,7 +15,7 @@ if [[ ${ENABLE_ACARS,,} =~ external ]]; then
   #   exit
   # fi
 
-  if [[ $((MIN_LOG_LEVEL)) -ge 4 ]]; then
+  if true || [[ $((MIN_LOG_LEVEL)) -ge 4 ]]; then
     # shellcheck disable=SC2016
     echo "Starting service" | stdbuf -oL awk '{print "[acars_server] " strftime("%Y/%m/%d %H:%M:%S", systime()) " " $0}'
   fi
@@ -24,9 +24,10 @@ if [[ ${ENABLE_ACARS,,} =~ external ]]; then
 
   # Listens for the output of acarsdec (UDP), and makes it available for multiple processes at TCP port 15550
   # shellcheck disable=SC2016
-  { socat -T 60 -u udp-listen:5550,fork,reuseaddr stdout \
-    | ncat -4 --keep-open --listen 0.0.0.0 15550; } 2>&1 \
-    | stdbuf -oL awk '{print "[acars_server] " strftime("%Y/%m/%d %H:%M:%S", systime()) " " $0}'
+  {
+      socat -T 60 -u udp-listen:5550,fork,reuseaddr stdout | { cat; kill -s INT 0; } \
+          | ncat -4 --keep-open --listen 0.0.0.0 15550 | { cat; kill -s INT 0; }
+  } 2>&1 | stdbuf -oL awk '{print "[acars_server] " strftime("%Y/%m/%d %H:%M:%S", systime()) " " $0}'
 
 else
   sleep 86400

--- a/rootfs/etc/services.d/vdlm2_server/run
+++ b/rootfs/etc/services.d/vdlm2_server/run
@@ -5,7 +5,7 @@ if [[ ${ENABLE_VDLM,,} =~ external ]]; then
 
   set -o pipefail
 
-  if [[ $((MIN_LOG_LEVEL)) -ge 4 ]]; then
+  if true || [[ $((MIN_LOG_LEVEL)) -ge 4 ]]; then
     # shellcheck disable=SC2016
     echo "Starting service" | stdbuf -oL awk '{print "[vdlm2_server] " strftime("%Y/%m/%d %H:%M:%S", systime()) " " $0}'
   fi
@@ -14,9 +14,10 @@ if [[ ${ENABLE_VDLM,,} =~ external ]]; then
 
   # Listen for the output of vdlm2dec (UDP), and make it available for multiple processes at TCP port 15555
   # shellcheck disable=SC2016
-  { socat -T 60 -u udp-listen:5555,fork,reuseaddr stdout \
-    | ncat -4 --keep-open --listen 0.0.0.0 15555; } 2>&1 \
-    | stdbuf -oL awk '{print "[vdlm2_server] " strftime("%Y/%m/%d %H:%M:%S", systime()) " " $0}'
+  {
+      socat -T 60 -u udp-listen:5555,fork,reuseaddr stdout | { cat; kill -s INT 0; } \
+          | ncat -4 --keep-open --listen 0.0.0.0 15555 | { cat; kill -s INT 0; }
+  } 2>&1 | stdbuf -oL awk '{print "[vdlm2_server] " strftime("%Y/%m/%d %H:%M:%S", systime()) " " $0}'
 else
   sleep 86400
 fi


### PR DESCRIPTION
when either socat / ncat in the pipe is closed for whatever reason, the
pipe keeps running as socat / ncat apparently don't care about stdout /
stdin being closed in this scenario
fix this with adding cat into the pipe which will exit when its stdin is
closed