### PR TITLE
Fix bug in handling errors with github version checking.

### DIFF
--- a/rootfs/webapp/acarshub_configuration.py
+++ b/rootfs/webapp/acarshub_configuration.py
@@ -229,7 +229,7 @@ def check_github_version():
                 "version_checker",
                 level=LOG_LEVEL["ERROR"],
             )
-            acarshub_logging.traceback(e)
+            acarshub_logging.acars_traceback(e)
             return
 
         github_version_from_json = jsonData["name"]


### PR DESCRIPTION
If the initial github version check cannot complete, the exception is not handled correctly and prevents routine tasks from being scheduled. Looks like a name change was missed? Easy fix. I noticed it when rrd was not getting updates.

Original stack trace:

```
...
[webapp      ] 2024/02/28 00:39:14   File "/usr/lib/python3.11/urllib/request.py", line 1391, in https_open
[webapp      ] 2024/02/28 00:39:14     return self.do_open(http.client.HTTPSConnection, req,
[webapp      ] 2024/02/28 00:39:14            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[webapp      ] 2024/02/28 00:39:14   File "/usr/lib/python3.11/urllib/request.py", line 1351, in do_open
[webapp      ] 2024/02/28 00:39:14     raise URLError(err)
[webapp      ] 2024/02/28 00:39:14 urllib.error.URLError: <urlopen error [Errno -3] Lookup timed out>
[webapp      ] 2024/02/28 00:39:14 During handling of the above exception, another exception occurred:
[webapp      ] 2024/02/28 00:39:14 Traceback (most recent call last):
[webapp      ] 2024/02/28 00:39:14   File "/usr/lib/python3.11/threading.py", line 1038, in _bootstrap_inner
[webapp      ] 2024/02/28 00:39:14     self.run()
[webapp      ] 2024/02/28 00:39:14   File "/usr/lib/python3.11/threading.py", line 975, in run
[webapp      ] 2024/02/28 00:39:14     self._target(*self._args, **self._kwargs)
[webapp      ] 2024/02/28 00:39:14   File "/webapp/acarshub.py", line 190, in scheduled_tasks
[webapp      ] 2024/02/28 00:39:14     acarshub_configuration.check_github_version()
[webapp      ] 2024/02/28 00:39:14   File "/webapp/acarshub_configuration.py", line 232, in check_github_version
[webapp      ] 2024/02/28 00:39:14     acarshub_logging.traceback(e)
[webapp      ] 2024/02/28 00:39:14 TypeError: 'module' object is not callable
[webapp      ] 2024/02/28 00:39:14 ERROR:[version_checker]: Error getting latest version from github
```

with this fix, the rrd updates happen.