### PR TITLE
Update docker guidance

### DIFF
--- a/Setting-Up-ACARSHub.MD
+++ b/Setting-Up-ACARSHub.MD
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This document is designed to show the most common `docker-compose.yaml` setup that requires minimal, if any, modifications.
+This document is designed to show the most common `compose.yaml` setup that requires minimal, if any, modifications.
 
 ### Migrating from v2 to v3/NextGen
 
@@ -42,11 +42,9 @@ If you have chosen to decode VDLM Data and have a RTL-SDR device dedicated to it
 
 Otherwise, remove the `dumpvdl2` section
 
-### docker-compose.yaml
+### compose.yaml
 
 ```yaml
-version: "3.8"
-
 volumes:
   acars_data:
 
@@ -146,10 +144,10 @@ services:
       #- AR_SEND_UDP_ACARS=acarshub:5550
       # The line below should be uncommented if you are receiving acars data from acarsdec AND want to feed airframes
       #- AR_SEND_UDP_ACARS=acarshub:5550;feed.airframes.io:5550
-      # The line below should uncommented if you are receiving VDLM and DO NOT want to feed aiframes
+      # The line below should uncommented if you are receiving VDLM, using dumpvdl2 OR using vdlm2dec and not want to feed
       #- AR_SEND_UDP_VDLM2=acarshub:5555
       # The line below should uncommented if you are receiving VDLM, using dumpvdl2 AND want to feed airframes
-      #- AR_SEND_UDP_VDLM2=acarshub:5555;feed.airframes.io:5552
+      #- AR_SEND_TCP_VDLM2=feed.airframes.io:5553
       # The line below should uncommented if you are receiving VDLM, using vdlm2dec AND want to feed airframes
       #- AR_SEND_UDP_VDLM2=acarshub:5555;feed.airframes.io:5555
       # The line below should uncommented if you are receiving dumpvdl2 AND using ZMQ (recommended)


### PR DESCRIPTION
* use TCP for feeding dumpvdl2 to airframes
* rename `docker-compose.yml` to `compose.yml`
* remove version from `compose.yml`