### PR TITLE
remove @types/webpack-dev-server

### DIFF
--- a/acarshub-typescript/package-lock.json
+++ b/acarshub-typescript/package-lock.json
@@ -35,7 +35,6 @@
         "@types/leaflet": "1.9.13",
         "@types/node": "22.7.7",
         "@types/showdown": "2.0.6",
-        "@types/webpack-dev-server": "^4.7.2",
         "autoprefixer": "10.4.20",
         "babel-loader": "9.2.1",
         "css-loader": "7.1.2",
@@ -2541,17 +2540,6 @@
       "dev": true,
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/@types/webpack-dev-server": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/@types/webpack-dev-server/-/webpack-dev-server-4.7.2.tgz",
-      "integrity": "sha512-Y3p0Fmfvp0MHBDoCzo+xFJaWTw0/z37mWIo6P15j+OtmUDLvznJWdZNeD7Q004R+MpQlys12oXbXsrXRmxwg4Q==",
-      "deprecated": "This is a stub types definition. webpack-dev-server provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "webpack-dev-server": "*"
       }
     },
     "node_modules/@types/ws": {

--- a/acarshub-typescript/package.json
+++ b/acarshub-typescript/package.json
@@ -20,7 +20,6 @@
     "@types/leaflet": "1.9.13",
     "@types/node": "22.7.7",
     "@types/showdown": "2.0.6",
-    "@types/webpack-dev-server": "^4.7.2",
     "autoprefixer": "10.4.20",
     "babel-loader": "9.2.1",
     "css-loader": "7.1.2",


### PR DESCRIPTION
fixes warning message
```
npm warn deprecated @types/webpack-dev-server@4.7.2: This is a stub types definition. webpack-dev-server provides its own type definitions, so you do not need this installed.
```