### PR TITLE
change undefined variables to fixed colors

### DIFF
--- a/acarshub-typescript/src/js-other/aircraft_icons.js
+++ b/acarshub-typescript/src/js-other/aircraft_icons.js
@@ -1255,8 +1255,8 @@ export function svgShapeToURI(shape, strokeWidth, scale) {
 
   if (!shape.path) {
     let svg = shape.svg
-      .replace("fillColor", fillColor)
-      .replace("strokeColor", strokeColor)
+      .replace("fillColor", "#ffffff")
+      .replace("strokeColor", "#000000")
       .replace("strokeWidth", strokeWidth);
     svg = svg.replace("SIZE", 'width="' + wi + 'px" height="' + he + 'px"');
     return "data:image/svg+xml;base64," + btoa(svg);


### PR DESCRIPTION
this fixes errors when certain icons on the ADS-B map are used