### PR TITLE
Move to custom python rrdtool for ACARS Hub

### DIFF
--- a/rootfs/webapp/requirements.txt
+++ b/rootfs/webapp/requirements.txt
@@ -3,6 +3,6 @@ Flask-SocketIO==5.5.1
 gevent==24.11.1
 gunicorn[gevent]==23.0.0
 requests==2.32.3
-rrdtool==0.1.16
+rrdtool @git+https://github.com/fredclausen/python-rrdtool.git
 schedule==1.2.2
 sqlalchemy==2.0.37


### PR DESCRIPTION
Upstream is not maintained. This fixes MacOS installation issues and protects us against future python versions in Debian where we'll get iced out with unsupported python features it previously relied on.