### PR TITLE
Revert "chore(deps): Bump node from 24.0.2-slim to 24.1.0-slim"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.1.0-slim AS acarshub-typescript-builder
+FROM node:24.0.2-slim AS acarshub-typescript-builder
 # pushd/popd
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 


### PR DESCRIPTION
This reverts commit fc335f45f8c0f695ff156b3432a99f56e17e22d2.

node 24.1.0 does not have an armv7 image
currently this image is still built for armv7, thus go back to node 24.0.2

probably a bug / build failure but that doesn't really matter