### PR TITLE
Revert "chore(deps): Bump node from 23.11.0-slim to 24.0.2-slim"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.0.2-slim AS acarshub-typescript-builder
+FROM node:23.11.0-slim AS acarshub-typescript-builder
 # pushd/popd
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 


### PR DESCRIPTION
This reverts commit fc42fad591d02b4cd28474b25a8109763f12a6e8.

it seems all versions of node 24 don't have the required image this somehow wasn't caught when stuff was merged 3 weeks ago because the build never happened?