### PR TITLE
chore(flake/precommit-base): `3076ff29` -> `01acaa60`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -101,11 +101,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783008725,
-        "narHash": "sha256-jGiy6+sxjNWXSjp25uoJuNfyH9zBK1PEDY0lVoL4ibQ=",
+        "lastModified": 1784288435,
+        "narHash": "sha256-ReRHaLgr/uVqdD8afFSn+myXIfpHeOhP0yYe0TJqAA8=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "bca82caa46d5ec0f5d422c61fb1e30bc51313cbe",
+        "rev": "43b3c1ab9d40fb1dbb008f451988a91e375825e9",
         "type": "github"
       },
       "original": {
@@ -254,11 +254,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1783710964,
-        "narHash": "sha256-Wlkb4KVuE16CSQ4XPtc4KGwf5KSp7LS7TWCXDicxtns=",
+        "lastModified": 1785487287,
+        "narHash": "sha256-3eF2bngygCD5mfzUKbXWYFXRSCmHcPnEiHZdbeyGc4k=",
         "owner": "FredSystems",
         "repo": "pre-commit-checks",
-        "rev": "3076ff29e23e52d8c3cd4c18d8ec086ed6ba8380",
+        "rev": "01acaa60808b41153970f9b0985ffb142b2ebfe5",
         "type": "github"
       },
       "original": {
@@ -297,11 +297,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1783663825,
-        "narHash": "sha256-TTrNVoFdEw8j0Hn+shP1KAsimTmszTWBIIUliTaAuY0=",
+        "lastModified": 1785476452,
+        "narHash": "sha256-/CXwCFPS41rb/JI2VitKCgVK6V5E6/sfw5ke3B9zyVQ=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "072adf9b18936c1062c48123a9b77891d5968f2c",
+        "rev": "6ef009bf4c4873cdc1a621826722bdea7c03e62c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                         | Message                                               |
| -------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`01acaa60`](https://github.com/fredsystems/pre-commit-checks/commit/01acaa60808b41153970f9b0985ffb142b2ebfe5) | `` chore(flake/rust-overlay): 471286a5 -> 6ef009bf `` |
| [`ff4b38d2`](https://github.com/fredsystems/pre-commit-checks/commit/ff4b38d25952a7b818f3b2e0edc749bf6c11b371) | `` chore(flake/nixpkgs): 753cc8a3 -> e2587cae ``      |
| [`db58dc2e`](https://github.com/fredsystems/pre-commit-checks/commit/db58dc2e11c3a90ba0df698aa6da09199b0ce283) | `` chore(flake/rust-overlay): 06817500 -> 471286a5 `` |
| [`8afeac59`](https://github.com/fredsystems/pre-commit-checks/commit/8afeac598b421e3b7b2772eaa699cbdfe967b76c) | `` chore(flake/git-hooks): bca82caa -> 43b3c1ab ``    |
| [`50bd447e`](https://github.com/fredsystems/pre-commit-checks/commit/50bd447e1d3206ea63716ef6c77ac0deba9f0276) | `` chore(flake/nixpkgs): e7a3ca80 -> 753cc8a3 ``      |
| [`1f9ef53d`](https://github.com/fredsystems/pre-commit-checks/commit/1f9ef53dcdced2019d6b8ccca22a3f9bb455b819) | `` chore(flake/rust-overlay): a286e5b9 -> 06817500 `` |
| [`7ffbe4d2`](https://github.com/fredsystems/pre-commit-checks/commit/7ffbe4d244ef810e871ff616988753131c9595e8) | `` updates ``                                         |
| [`538e1735`](https://github.com/fredsystems/pre-commit-checks/commit/538e1735c9dc44bb8fc3bc2918a3a5618896a60d) | `` updates ``                                         |
| [`53d43fa0`](https://github.com/fredsystems/pre-commit-checks/commit/53d43fa05b4de2c1041d41a21d58efae2b674c59) | `` chore(flake/nixpkgs): 0bb7ec54 -> e7a3ca80 ``      |
| [`fc8d9b93`](https://github.com/fredsystems/pre-commit-checks/commit/fc8d9b9382519b7f1c256da05eebe82aa7aedfaf) | `` chore(flake/rust-overlay): 072adf9b -> a286e5b9 `` |