### PR TITLE
chore(flake/npm-chck): `da47b265` -> `926b57a6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         "precommit-base": "precommit-base"
       },
       "locked": {
-        "lastModified": 1783307814,
-        "narHash": "sha256-y7Odk1jaAqnEL/du64hWHBzKut+1cHTd6PYhawSvC8Y=",
+        "lastModified": 1783913686,
+        "narHash": "sha256-ir9YuGY1aoz+kFlrb9m3meOQfzO9wd8RoqOMUbqqlj8=",
         "owner": "FredSystems",
         "repo": "npm-chck",
-        "rev": "da47b2651158a4c21c88305f7383b5033d064337",
+        "rev": "926b57a66293aa42699a5a430ee8bd3cbb299ce9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                      |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`926b57a6`](https://github.com/fredsystems/npm-chck/commit/926b57a66293aa42699a5a430ee8bd3cbb299ce9) | `` chore(deps): lock file maintenance (#45) ``               |
| [`8cea56c4`](https://github.com/fredsystems/npm-chck/commit/8cea56c4887ac29dd85a1b95c83972cdd7b8e1fb) | `` chore(deps): lock file maintenance (#44) ``               |
| [`c991634d`](https://github.com/fredsystems/npm-chck/commit/c991634dc3134ff3dbfd9a1f04b18e37bb5b190d) | `` chore(deps): lock file maintenance (#43) ``               |
| [`214fb7e6`](https://github.com/fredsystems/npm-chck/commit/214fb7e6d0452bac0b6054740f54d83e5ea0cae6) | `` chore(deps): lock file maintenance (#41) ``               |
| [`dc5dc89d`](https://github.com/fredsystems/npm-chck/commit/dc5dc89dd272fc11d9aeebcdb6c370e6cbffb1b8) | `` chore(deps): update dependency vitest to v4.1.10 (#42) `` |