### PR TITLE
chore(flake/nixpkgs): `0bb7ec54` -> `1559d3da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -139,11 +139,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1783522502,
-        "narHash": "sha256-iffAls3iaNTyJC2faYcUXSI+Gp02cDjYl+MygxKl2GI=",
+        "lastModified": 1785454630,
+        "narHash": "sha256-LQy14TZp77TwbQf40gg1V3jo8FwJG0jGDkAH+zRHqg8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0bb7ec54c8483066ec9d7720e780a5caa71f8612",
+        "rev": "1559d3daa3ecc813a650b79375ea61b6741b8746",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                         |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
| [`4963c556`](https://github.com/NixOS/nixpkgs/commit/4963c5561cacad806f1aa4690e569d6b2ac0516d) | `` pretalx: pin django-hierarkey at 2.0.1 ``                                                                    |
| [`50c67d6e`](https://github.com/NixOS/nixpkgs/commit/50c67d6ef14004a47e2164d436236fda7d0f1e1b) | `` python3Packages.css-parser: enable __structuredAttrs ``                                                      |
| [`dd6a1ee8`](https://github.com/NixOS/nixpkgs/commit/dd6a1ee8dfcdba7f5b3f3a3bd63f9d29a737efcd) | `` noctalia: 5.0.0-beta.6 -> 5.0.0-beta.7 ``                                                                    |
| [`1a76c7fa`](https://github.com/NixOS/nixpkgs/commit/1a76c7fa5e1bb499f0bbdaa41e97fccb47981b64) | `` evcc: 0.312.1 -> 0.313.0 ``                                                                                  |
| [`aa82506a`](https://github.com/NixOS/nixpkgs/commit/aa82506a572fee02e0a8f9f49df8b2d5b7be276e) | `` python3Packages.mwclient: modernise ``                                                                       |
| [`e8232cbe`](https://github.com/NixOS/nixpkgs/commit/e8232cbe37d80c3b8ada444cd842299ef86057d6) | `` python3Packages.mwclient: adopt ``                                                                           |
| [`f4ca7e94`](https://github.com/NixOS/nixpkgs/commit/f4ca7e947eb4a1bcc2a0a243fc084fc74561a40a) | `` python3Packages.mwclient: 0.11.0 -> 0.11.0-unstable-2026-05-15 ``                                            |
| [`801357a6`](https://github.com/NixOS/nixpkgs/commit/801357a6304e58535b64ca3895ec350c7fab3f6f) | `` pretix.plugins.servicefees: 1.15.0 -> 1.15.1 ``                                                              |
| [`d71a5a73`](https://github.com/NixOS/nixpkgs/commit/d71a5a738af411e4f474c2b079b7733a7f2c6c35) | `` pretix.plugins.mollie: 2.5.7 -> 2.5.8 ``                                                                     |
| [`309a4fef`](https://github.com/NixOS/nixpkgs/commit/309a4fef2f06a6922da4dddb0e285e94886351e1) | `` pretix: 2026.6.1 -> 2026.7.0 ``                                                                              |
| [`2ed9a652`](https://github.com/NixOS/nixpkgs/commit/2ed9a652ccf927083397c96d9f56709f1f917d17) | `` python3Packages.django-redis: 6.0.0 -> 7.0.0 ``                                                              |
| [`60a40a91`](https://github.com/NixOS/nixpkgs/commit/60a40a914a619bca39339416eaae61bd3afe68e7) | `` python3Packages.django-querytagger: init at 0.0.3 ``                                                         |
| [`7f1c81fc`](https://github.com/NixOS/nixpkgs/commit/7f1c81fcef43b2f739ce369893e6622f879b9d3f) | `` python3Packages.django-hierarkey: 2.0.1 -> 2.0.2 ``                                                          |
| [`8a054825`](https://github.com/NixOS/nixpkgs/commit/8a05482531083d0a16abeebd3e124f41f558d7cd) | `` python3Packages.django-formtools: 2.6.1 -> 2.7 ``                                                            |
| [`4b22488a`](https://github.com/NixOS/nixpkgs/commit/4b22488ab3b759602d84032fe2abe742391f7d7e) | `` python3Packages.django-countries: 8.2.0 -> 9.0.0 ``                                                          |
| [`62b4ac5f`](https://github.com/NixOS/nixpkgs/commit/62b4ac5f987ff7278f93797e781190a307f6150e) | `` python3Packages.exa-py: 2.16.1 -> 2.16.2 ``                                                                  |
| [`8bb4389e`](https://github.com/NixOS/nixpkgs/commit/8bb4389e2be9e36077043f2327e9abdf7e0b888c) | `` octodns-providers.bind: 1.0.1 -> 1.1.0 ``                                                                    |
| [`b0b33cff`](https://github.com/NixOS/nixpkgs/commit/b0b33cff8f366f9d72acbe9abb7275a4115c0a8b) | `` forgejo: 16.0.1 -> 16.0.2 ``                                                                                 |
| [`f926ef26`](https://github.com/NixOS/nixpkgs/commit/f926ef268918b8df93b8dd12fe6e995b914f56be) | `` octodns-providers.ovh: 1.1.0 -> 1.2.0 ``                                                                     |
| [`e4cda108`](https://github.com/NixOS/nixpkgs/commit/e4cda1086938a9cc0525a62f65cd16514064666e) | `` openspec: add sarahec as maintainer ``                                                                       |
| [`95b8afde`](https://github.com/NixOS/nixpkgs/commit/95b8afde029581eae8bfd57efe00f3310651de4a) | `` openspec: 1.4.1 -> 1.7.0 ``                                                                                  |
| [`3965a5d0`](https://github.com/NixOS/nixpkgs/commit/3965a5d073c94482a8bb447a8b67f9ad5c4e97e3) | `` ctx7: 0.5.5 -> 0.5.7 ``                                                                                      |
| [`9dd81112`](https://github.com/NixOS/nixpkgs/commit/9dd81112e2975943c947a2815e1a2ad3dc3aebe5) | `` terraform-providers.spotinst_spotinst: 1.238.0 -> 1.238.1 ``                                                 |
| [`42de6e01`](https://github.com/NixOS/nixpkgs/commit/42de6e01ec8499904d39a22ed8f9e798b247fc14) | `` forgejo-lts: 15.0.5 -> 15.0.6 ``                                                                             |
| [`76b406e9`](https://github.com/NixOS/nixpkgs/commit/76b406e9ebc1bfa8eb6b123c9f8a8426c5edb1d5) | `` mullvad: use rust-jemalloc-sys to fix 16k pagesize ``                                                        |
| [`972aca3d`](https://github.com/NixOS/nixpkgs/commit/972aca3d586d036929ea049ad17021ad4629a921) | `` fleeting-plugin-aws: 1.2.0 -> 1.3.0 ``                                                                       |
| [`a60cd83c`](https://github.com/NixOS/nixpkgs/commit/a60cd83c619c81b4b46154e5f249677dab483388) | `` python3Packages.guntamatic: 1.9.2 -> 1.9.3 ``                                                                |
| [`0cf7e3e5`](https://github.com/NixOS/nixpkgs/commit/0cf7e3e54e7ddbf459721989995ae5323a1c4943) | `` python3Packages.django-tenants: fix version in pyproject.toml ``                                             |
| [`47f32cbd`](https://github.com/NixOS/nixpkgs/commit/47f32cbdcef76c1821325121c335e682bc3aee7c) | `` python3Packages.python-iso639: 2026.4.20 -> 2026.7.23 ``                                                     |
| [`57ea3815`](https://github.com/NixOS/nixpkgs/commit/57ea381571f49e56eee0065894406a241a68b395) | `` userborn: 1.0.0 -> 1.0.1 ``                                                                                  |
| [`b9fa23fd`](https://github.com/NixOS/nixpkgs/commit/b9fa23fd2c35f479475403219c46e66799eb05b5) | `` dropbear: 2026.93 -> 2026.94 ``                                                                              |
| [`a7e53881`](https://github.com/NixOS/nixpkgs/commit/a7e53881a447034c92887e1f14bddcc5bb47c29d) | `` ggml: 0.17.0 -> 0.18.0 ``                                                                                    |
| [`17d9b560`](https://github.com/NixOS/nixpkgs/commit/17d9b5607a1847bc535cbdb9ae15fa186e6bb57b) | `` flatpak-builder-tools: init at 0-unstable-2026-06-09 ``                                                      |
| [`fe00e023`](https://github.com/NixOS/nixpkgs/commit/fe00e0239594144ef7f0d881de991fd6beda9082) | `` tabularis: 0.9.2 -> 0.17.0 ``                                                                                |
| [`51d6cb46`](https://github.com/NixOS/nixpkgs/commit/51d6cb46a15af4c95f38afdf44bde5a28db9df18) | `` nats-server: 2.14.3 -> 2.14.4 ``                                                                             |
| [`b6ec6372`](https://github.com/NixOS/nixpkgs/commit/b6ec63725c7826417d4f4a190dbd514c692a71cd) | `` fzf-make: 0.70.0 -> 0.73.0 ``                                                                                |
| [`f9d8d9b4`](https://github.com/NixOS/nixpkgs/commit/f9d8d9b432706440b5235c9df0aad677223ddb17) | `` tableplus: 0.1.296 -> 0.1.308 ``                                                                             |
| [`1be3372f`](https://github.com/NixOS/nixpkgs/commit/1be3372ff3b7e33d14fa2707eeec766c16ed84ce) | `` python3Packages.rstcheck-core: migrate to finalAttrs ``                                                      |
| [`95044abd`](https://github.com/NixOS/nixpkgs/commit/95044abdad28fe82829149c1a1dd501d8bb90929) | `` python3Packages.filedepot: migrate to finalAttrs ``                                                          |
| [`6d6708d9`](https://github.com/NixOS/nixpkgs/commit/6d6708d9955fd646e86b4dbc700dad023f443b0b) | `` python3Packages.led-ble: migrate to finalAttrs ``                                                            |
| [`ca41f719`](https://github.com/NixOS/nixpkgs/commit/ca41f7190b45aa6a21ae01ec7ed74ac68a12d9b3) | `` cockpit: 364 -> 365 ``                                                                                       |
| [`2ae102cc`](https://github.com/NixOS/nixpkgs/commit/2ae102cc6708a31e1ab89450cdb78da7699ef81b) | `` python3Packages.tencentcloud-sdk-python: 3.1.143 -> 3.1.146 ``                                               |
| [`fc0c8316`](https://github.com/NixOS/nixpkgs/commit/fc0c8316bffb94d5e7864e03288227107982a9d3) | `` python3Packages.tencentcloud-sdk-python: 3.1.142 -> 3.1.143 ``                                               |
| [`599ca442`](https://github.com/NixOS/nixpkgs/commit/599ca4425ffbe4086d37d7311468d8284772a0c8) | `` python313Packages.iamdata: 0.1.202607291 -> 0.1.202607301 ``                                                 |
| [`36160485`](https://github.com/NixOS/nixpkgs/commit/3616048583461d39985ce52f0c044f3c6623c56a) | `` harper-desktop: 2.6.0 -> 2.7.0 ``                                                                            |
| [`b43f73b7`](https://github.com/NixOS/nixpkgs/commit/b43f73b726ed0c9d36bc41454317bcef73f2a271) | `` nautilus-open-any-terminal: 0.8.1 -> 0.8.3 ``                                                                |
| [`5ea859f9`](https://github.com/NixOS/nixpkgs/commit/5ea859f95cbed2592f43af9279f715b8ef6bde82) | `` collada-dom: 2.5.3 -> 2.5.4 ``                                                                               |
| [`6b4f33f7`](https://github.com/NixOS/nixpkgs/commit/6b4f33f7459de43925c26c5ba4282b7eac073188) | `` mcp-gateway: 3.3.2 -> 3.4.0 ``                                                                               |
| [`470532e6`](https://github.com/NixOS/nixpkgs/commit/470532e68f1d7972aa5a6abf5277224f234ecdbd) | `` terraform-providers.hashicorp_google-beta: 7.40.0 -> 7.42.0 ``                                               |
| [`c07126bb`](https://github.com/NixOS/nixpkgs/commit/c07126bb5cea16b095df60c744b52b09c85a71b0) | `` terraform-providers.aiven_aiven: 4.60.0 -> 4.61.0 ``                                                         |
| [`6c26c265`](https://github.com/NixOS/nixpkgs/commit/6c26c265ab728683164b8db73af34e6331db5cad) | `` emacsPackages.lsp-bridge: 0-unstable-2025-11-13 -> 0-unstable-2026-06-27 ``                                  |
| [`f148e9e0`](https://github.com/NixOS/nixpkgs/commit/f148e9e0ab5dfc63735046c02cdebb09051e8a11) | `` libeconf: 0.8.3 -> 0.8.4 ``                                                                                  |
| [`99373fe3`](https://github.com/NixOS/nixpkgs/commit/99373fe373680ab0bd64328ce8b9f64114927746) | `` proxyman: 3.11.0 -> 3.16.1 ``                                                                                |
| [`765b79b4`](https://github.com/NixOS/nixpkgs/commit/765b79b490320d29e04469b26a787e11484097b9) | `` maintainers: remove argrat ``                                                                                |
| [`60bae0e3`](https://github.com/NixOS/nixpkgs/commit/60bae0e3205dc5d5f0c306bae214f02b676f9502) | `` borealis-cursors: remove argrat from maintainers ``                                                          |
| [`1d508169`](https://github.com/NixOS/nixpkgs/commit/1d50816913d79ec7aa2e2b1ad19aea357e1bae0a) | `` sing-box: 1.13.14 -> 1.13.15 ``                                                                              |
| [`46eb197f`](https://github.com/NixOS/nixpkgs/commit/46eb197f580c44a7390a3e43ee62f18a6245f951) | `` gh-stack: add antoineco as maintainer ``                                                                     |
| [`7b2df581`](https://github.com/NixOS/nixpkgs/commit/7b2df5816fa0665ab19403e38b2b47be94293ee1) | `` gh-stack: 0.0.4 -> 0.1.0 ``                                                                                  |
| [`42490608`](https://github.com/NixOS/nixpkgs/commit/42490608f1829d36d8e54deaaf91bc1225d8801b) | `` diffoscope: remove outdated patch for androguard ``                                                          |
| [`09e933bb`](https://github.com/NixOS/nixpkgs/commit/09e933bb5154f51ce7fb7289d202f8cbf5a570e7) | `` collada-dom: doCheck ``                                                                                      |
| [`3ab3d5b7`](https://github.com/NixOS/nixpkgs/commit/3ab3d5b752889692b692733c07c0a6ebc5378bd1) | `` wapiti: 3.3.0 -> 3.3.1 ``                                                                                    |
| [`21082a95`](https://github.com/NixOS/nixpkgs/commit/21082a9546847855bc6d185a9799f17a587585ce) | `` defuddle: 0.19.1 -> 0.19.2 ``                                                                                |
| [`523c7be5`](https://github.com/NixOS/nixpkgs/commit/523c7be54a4cfc716f9b51825420e777677706b7) | `` collada-dom: add missing dependencies ``                                                                     |
| [`866275ac`](https://github.com/NixOS/nixpkgs/commit/866275ac41bf821bfecd358d4eddfdb972d5e389) | `` android-studio{,-for-platform}: use gtk3 for GTK LaF ``                                                      |
| [`8b38b3d8`](https://github.com/NixOS/nixpkgs/commit/8b38b3d8ee10df4b203d0bdc29f9735dc910828f) | `` roxctl: 4.11.1 -> 4.11.2 ``                                                                                  |
| [`ba8b42f3`](https://github.com/NixOS/nixpkgs/commit/ba8b42f34b3a1adcdea2161820f9d94df0245426) | `` yascreen: 2.13 -> 2.14 ``                                                                                    |
| [`a6fafb92`](https://github.com/NixOS/nixpkgs/commit/a6fafb9250c3882be43fbaedb736fd0c56e8cc0f) | `` pi-coding-agent: 0.82.1 -> 0.83.0 ``                                                                         |
| [`73145e57`](https://github.com/NixOS/nixpkgs/commit/73145e57e147ec718920a7cdd3955e84fd15907d) | `` ldap-manager: 1.4.1 -> 1.5.1 ``                                                                              |
| [`78671898`](https://github.com/NixOS/nixpkgs/commit/78671898108956c9cc640976819a4390c83fb3fe) | `` node-red: 5.0.1 -> 5.0.2 ``                                                                                  |
| [`ace496d1`](https://github.com/NixOS/nixpkgs/commit/ace496d1507235d33090739585057f8bd793a16b) | `` python3Packages.free-proxy: remove pip-chill dep ``                                                          |
| [`09a57e8f`](https://github.com/NixOS/nixpkgs/commit/09a57e8fc174d4c05d0397bdd23213527e05aebd) | `` keycloakPlugins.keycloak-orgs: 0.168 -> 0.172 ``                                                             |
| [`89f8a5a4`](https://github.com/NixOS/nixpkgs/commit/89f8a5a4fbda761194f834c65aa0acfec1501da8) | `` keycloakPlugins.keycloak-magic-link: 0.74 -> 0.75 ``                                                         |
| [`b6487586`](https://github.com/NixOS/nixpkgs/commit/b64875861ae98e2a0444db2d3e4167a99aa8a793) | `` music-assistant-desktop: 0.6.0 -> 0.6.2 ``                                                                   |
| [`302bfb97`](https://github.com/NixOS/nixpkgs/commit/302bfb9731f7bd70c82cdf3b00b87368e78cf3c9) | `` syft: 1.49.0 -> 1.50.0 ``                                                                                    |
| [`55fb3627`](https://github.com/NixOS/nixpkgs/commit/55fb362744e081b4986da0e94fc3a169db673186) | `` libretro.fceumm: 0-unstable-2026-07-06 -> 0-unstable-2026-07-28 ``                                           |
| [`4e57e4ee`](https://github.com/NixOS/nixpkgs/commit/4e57e4ee5b1101b4e2323d8721fe7b94988df91a) | `` fastcdr: 2.3.6 -> 2.4.0 ``                                                                                   |
| [`fce6f3c0`](https://github.com/NixOS/nixpkgs/commit/fce6f3c024aa4e34c46a1a1ccd9b142cda5b61db) | `` paratest: 7.23.0 -> 7.23.1 ``                                                                                |
| [`60af959a`](https://github.com/NixOS/nixpkgs/commit/60af959ae6c02a167a6073b413f907742e54e195) | `` lib.teams.pulumi: init and make maintainer of Pulumi and its SDKs ``                                         |
| [`f98d62ad`](https://github.com/NixOS/nixpkgs/commit/f98d62ad40e839291dc81e0c05b6a94b92480115) | `` python3Packages.cuda-pathfinder: 1.5.6 -> 1.6.0 ``                                                           |
| [`602f1e4b`](https://github.com/NixOS/nixpkgs/commit/602f1e4b6e365f995147f9d82c0e5b5298b67a0d) | `` flyway: 13.0.0 -> 13.1.0 ``                                                                                  |
| [`93dcca0c`](https://github.com/NixOS/nixpkgs/commit/93dcca0cc69e2ef7d3bb65d33c87b72e75a9fbc4) | `` vscode-extensions.leanprover.lean4: 0.0.237 -> 0.0.239 ``                                                    |
| [`596e02ac`](https://github.com/NixOS/nixpkgs/commit/596e02ac797508df1bb06e54ce3dec45ca69295e) | `` python3Packages.licomp-oslc-handbook: fix darwin build ``                                                    |
| [`b95cbcf1`](https://github.com/NixOS/nixpkgs/commit/b95cbcf1993cf00c6ea28ae105d38666e163029a) | `` appium-inspector: 2026.5.1 -> 2026.7.1 ``                                                                    |
| [`04f6dc97`](https://github.com/NixOS/nixpkgs/commit/04f6dc9792a5ab97501433d43688ed56d0fe6b53) | `` plugp100: 5.1.5 -> 6.0.0.dev2 ``                                                                             |
| [`77ef6295`](https://github.com/NixOS/nixpkgs/commit/77ef6295c597e2cd9afe8127882b6d682d32359d) | `` terraform-providers.launchdarkly_launchdarkly: 2.30.1 -> 3.1.1 ``                                            |
| [`54c08d3c`](https://github.com/NixOS/nixpkgs/commit/54c08d3c5b637ab3b342af0012e3473cc97aae6e) | `` mastodon: patch CVE-2026-66066/GHSA-xr9x-r78c-5hrm in activesupport gem ``                                   |
| [`88a51bec`](https://github.com/NixOS/nixpkgs/commit/88a51becdbdbea27ee1aaad8a518d2c0fc74b12d) | `` python3Packages.sciline: disable 2 failing tests ``                                                          |
| [`8428565a`](https://github.com/NixOS/nixpkgs/commit/8428565aad790758a415cf378446f36f5132a38c) | `` libretro.sameboy: 0-unstable-2026-04-20 -> 0-unstable-2026-07-23 ``                                          |
| [`74e93976`](https://github.com/NixOS/nixpkgs/commit/74e93976ac41f9da6bbf9895e83ed77e16173de6) | `` tiny-cuda-nn: fix build ``                                                                                   |
| [`d4aa3b61`](https://github.com/NixOS/nixpkgs/commit/d4aa3b61d14d7b2686a1573968ac5b151fbc6693) | `` wordbook: 0.4.0 -> 1.0.0 ``                                                                                  |
| [`f3e101e0`](https://github.com/NixOS/nixpkgs/commit/f3e101e05151c9f671c12914e69692823aa532da) | `` bashunit: update 0.40.0 -> 0.44.0 ``                                                                         |
| [`bafffe88`](https://github.com/NixOS/nixpkgs/commit/bafffe88cd16e808ea84335e0759d7330ded650b) | `` xdg-desktop-portal-hyprland: 1.4.0 -> 1.4.1 ``                                                               |
| [`4cf61dec`](https://github.com/NixOS/nixpkgs/commit/4cf61dec5567956021944e6b5eca79a3f25afb31) | `` python3Packages.knx-frontend: 2026.7.17.104339 -> 2026.7.23.145751 ``                                        |
| [`f00d8712`](https://github.com/NixOS/nixpkgs/commit/f00d8712a1e3ad389f03249eda600ccc3bb27e87) | `` python3Packages.jellyfin-apiclient-python: 1.15.0 -> 1.17.0 ``                                               |
| [`7d02c880`](https://github.com/NixOS/nixpkgs/commit/7d02c880fa7941ca4cf7cc012284f6c0fa81a084) | `` meilisearch: 1.50.0 -> 1.51.0 ``                                                                             |
| [`ecd882c3`](https://github.com/NixOS/nixpkgs/commit/ecd882c3487405c28e597ecbe520ebc82746d522) | `` python3Packages.led-ble: 1.1.11 -> 1.1.12 ``                                                                 |
| [`28fc6125`](https://github.com/NixOS/nixpkgs/commit/28fc61251e7a44a2575a4a3a0fa480fc117ccb5c) | `` netbird: 0.75.1 -> 0.76.0 ``                                                                                 |
| [`c911f3c1`](https://github.com/NixOS/nixpkgs/commit/c911f3c1c71f757b3f5b9499157b2647f7867007) | `` python3Packages.torchaudio: skip metadata check for gpuCheck ``                                              |
| [`6a330ac8`](https://github.com/NixOS/nixpkgs/commit/6a330ac8ff78f950e7b9d2fb4c428ad9b85f86ca) | `` python3Packages.tuya-device-handlers: 0.0.25 -> 0.0.26 ``                                                    |
| [`bbed63d2`](https://github.com/NixOS/nixpkgs/commit/bbed63d2ec4de2283a66a5db734ebff0f7c44a3a) | `` unpoller: 3.3.3 -> 3.3.4 ``                                                                                  |
| [`3b680db9`](https://github.com/NixOS/nixpkgs/commit/3b680db983557420a8b2d495c626b9e977950031) | `` sandbox-runtime: 0.0.66 -> 0.0.68 ``                                                                         |
| [`cc6f47fa`](https://github.com/NixOS/nixpkgs/commit/cc6f47fac11e91520e91d2c94cbdc91952bc200c) | `` python3Packages.lerobot: fix ``                                                                              |
| [`e5a89c72`](https://github.com/NixOS/nixpkgs/commit/e5a89c72bae6b2f3e3b6336f393450c16126c51d) | `` python3Packages.anndata: 0.12.7 -> 0.13.2 ``                                                                 |
| [`9c8faf0e`](https://github.com/NixOS/nixpkgs/commit/9c8faf0e79284348f054504dcda0074165e14d48) | `` vscode-extensions.divyanshuagrawal.competitive-programming-helper: 2026.7.1784455023 -> 2026.7.1784984280 `` |
| [`778677bd`](https://github.com/NixOS/nixpkgs/commit/778677bd03c091ec02e5e0282467f02dd049bd13) | `` sentry-native: 0.15.4 -> 0.16.0 ``                                                                           |
| [`8516a7e3`](https://github.com/NixOS/nixpkgs/commit/8516a7e327302ecb279c576d8d4a9c492fc736b6) | `` stalwart_0_15: disable automatic update by nixpkgs-update ``                                                 |
| [`14e9d479`](https://github.com/NixOS/nixpkgs/commit/14e9d479e60563b19205a3700be27228f46c0655) | `` sure: 0.7.1 -> 0.7.2 && patch CVE-2026-66066 ``                                                              |
| [`48fc23dc`](https://github.com/NixOS/nixpkgs/commit/48fc23dc48b10db27c7b206c0dfcf42118e290c3) | `` entire: 0.8.42 -> 0.9.0 ``                                                                                   |
| [`e27ba69c`](https://github.com/NixOS/nixpkgs/commit/e27ba69cee2b9eea42261bcb4415edf5916ce0d5) | `` stalwart-vandelay: 1.0.6 -> 1.0.7 ``                                                                         |
| [`15b0beb6`](https://github.com/NixOS/nixpkgs/commit/15b0beb60b26de404ae0753c1a3b9caf84379f53) | `` pokemonsay: 1.0.0 -> 2.0.0 ``                                                                                |
| [`2d90c231`](https://github.com/NixOS/nixpkgs/commit/2d90c2317c00c780cd7ee2a11dcc8b6607313f46) | `` monkeys-audio: 13.19 -> 13.20 ``                                                                             |
| [`2a0fdccd`](https://github.com/NixOS/nixpkgs/commit/2a0fdccdc53df97252636a2e49cc3fad43ff2c30) | `` tremotesf: 2.10.0 -> 2.10.1 ``                                                                               |
| [`bdc10547`](https://github.com/NixOS/nixpkgs/commit/bdc10547992688a17203dffb846802831126927f) | `` versatiles: 4.6.0 -> 4.6.1 ``                                                                                |
| [`79a9af69`](https://github.com/NixOS/nixpkgs/commit/79a9af696bb42c563d0f5057423ffcf65235484c) | `` blazesym-c: 0.1.9 -> 0.1.10 ``                                                                               |
| [`da758935`](https://github.com/NixOS/nixpkgs/commit/da758935b248078c2834bc1fca4564defe59cc05) | `` rustypaste-cli: 0.9.5 -> 0.10.0 ``                                                                           |
| [`cfb457a2`](https://github.com/NixOS/nixpkgs/commit/cfb457a2abe5269efb3672b2e4e06c2966961bad) | `` reframe: 1.19.0 -> 1.19.1 ``                                                                                 |
| [`5653b67b`](https://github.com/NixOS/nixpkgs/commit/5653b67bbcb77fa68b18837d23fc3f970bf8ffea) | `` zizmor: 1.27.0 -> 1.28.0 ``                                                                                  |
| [`ff7c73d5`](https://github.com/NixOS/nixpkgs/commit/ff7c73d534dc0b374092fee8e835b7f90f258231) | `` stalwart-cli: 1.0.11 -> 1.0.12 ``                                                                            |
| [`5446c88b`](https://github.com/NixOS/nixpkgs/commit/5446c88be7cb200f6c5f4f8f5c249c94b6df919e) | `` rPackages.netboost: mark broken ``                                                                           |
| [`f01a5d85`](https://github.com/NixOS/nixpkgs/commit/f01a5d859c98ca8f6bec22890c248b1d6985e959) | `` todoist-cli: 3.0.0 -> 3.0.6 ``                                                                               |
| [`b13cbeb8`](https://github.com/NixOS/nixpkgs/commit/b13cbeb847b376c3630757fd5b1e355b0e2d50bd) | `` webdav: 5.14.0 -> 5.14.1 ``                                                                                  |
| [`cbc7cf53`](https://github.com/NixOS/nixpkgs/commit/cbc7cf53f282e5413538e190baeb9ae8f5f3f81d) | `` grip: drop ``                                                                                                |
| [`34203c46`](https://github.com/NixOS/nixpkgs/commit/34203c46d6df1c91f09063d96ee1c1790bc53b12) | `` gkrellm: drop ``                                                                                             |
| [`d8b5b8de`](https://github.com/NixOS/nixpkgs/commit/d8b5b8de508beac0bd21494ca913b82b135e6120) | `` crossfire-client: drop ``                                                                                    |
| [`cf9837a5`](https://github.com/NixOS/nixpkgs/commit/cf9837a51a82955fdaa376dc2d55cf02e9f73a26) | `` emscriptenPackages.xmlmirror: fix version, update fetcher ``                                                 |
| [`652de477`](https://github.com/NixOS/nixpkgs/commit/652de477012ab7a07ef720d227f1e39789149631) | `` inshellisense: 0.0.1 -> 0.0.2 ``                                                                             |
| [`5aa3b724`](https://github.com/NixOS/nixpkgs/commit/5aa3b724e744fc86e935abe4fd86fdf7b88674ec) | `` keycloakPlugins.keycloak-home-idp-discovery: 26.2.1 -> 26.2.2 ``                                             |
| [`163bf70b`](https://github.com/NixOS/nixpkgs/commit/163bf70b6fa4fb684ba81f115dd8efca65ec7030) | `` keycloakPlugins.keycloak-restrict-client-auth: 26.1.0 -> 26.1.1 ``                                           |
| [`82cc71b6`](https://github.com/NixOS/nixpkgs/commit/82cc71b605683de3fd7de50ac693471ba508c8f8) | `` verbiste: don't build gtk2 app ``                                                                            |
| [`4907dd61`](https://github.com/NixOS/nixpkgs/commit/4907dd61418b5094892d84e40699698e5b075dfb) | `` glusterfs: fuse -> fuse3 ``                                                                                  |
| [`6fb6476d`](https://github.com/NixOS/nixpkgs/commit/6fb6476d930a54776dde1fc6528faeda6fcddb17) | `` just-lsp: 0.4.8 -> 0.5.1 ``                                                                                  |
| [`6f613de5`](https://github.com/NixOS/nixpkgs/commit/6f613de5b6ba9085868518652eaaa5d3f1b45d9b) | `` snapdragon-profiler: drop ``                                                                                 |
| [`1887e062`](https://github.com/NixOS/nixpkgs/commit/1887e062010d51c9a471419bee147d881bb020fb) | `` poetryPlugins.poetry-plugin-export: update version hash ``                                                   |
| [`3c61e6a8`](https://github.com/NixOS/nixpkgs/commit/3c61e6a82f2de7d5f037340127acf980de9de9d0) | `` poetry: fix tests broken due to virtualenv update ``                                                         |
| [`23b49afb`](https://github.com/NixOS/nixpkgs/commit/23b49afbbeaa699dbab67939faffabcd3322f5ae) | `` linuxPackages.broadcom_sta: 6.30.223.271-59 -> 6.30.223.271-63 ``                                            |
| [`fae8e21b`](https://github.com/NixOS/nixpkgs/commit/fae8e21b1ec02eb3797478346490123aa1b003a9) | `` gtk_engines: drop ``                                                                                         |
| [`dc83067c`](https://github.com/NixOS/nixpkgs/commit/dc83067caac90eb045fb1d03b7940a4f2964973f) | `` chromium,chromedriver: 150.0.7871.186 -> 151.0.7922.71 ``                                                    |
| [`f544c0a2`](https://github.com/NixOS/nixpkgs/commit/f544c0a28a24a7f8780c30e8cc136ef64e74bac7) | `` paper-gtk-theme: drop ``                                                                                     |
| [`d2b09ba6`](https://github.com/NixOS/nixpkgs/commit/d2b09ba691efd478e013b1eca418b506fbc47db9) | `` kn: 1.22.1 -> 1.23.0 ``                                                                                      |
| [`00bd6945`](https://github.com/NixOS/nixpkgs/commit/00bd694555cdb0a674f277051345b24a4c025dab) | `` enblend-enfuse: fix version, clean up ``                                                                     |
| [`1b20a0b1`](https://github.com/NixOS/nixpkgs/commit/1b20a0b11469e90897d943e662231e6ec4489fe6) | `` haproxy: 3.4.2 -> 3.4.3 ``                                                                                   |
| [`4fa8ba9e`](https://github.com/NixOS/nixpkgs/commit/4fa8ba9ea6f9bed7762bebaf3c07582ef3656aca) | `` bpfmon: 2.53 -> 2.60 ``                                                                                      |
| [`e1f5edb9`](https://github.com/NixOS/nixpkgs/commit/e1f5edb9638351d0757769dc1458b86552ff2f8b) | `` downkyicore: 1.0.24 -> 1.0.32 ``                                                                             |
| [`c93e4f16`](https://github.com/NixOS/nixpkgs/commit/c93e4f1630a02eb789afc17d2238941231039fba) | `` perplexity-mcp: 0-unstable-2026-06-17 -> 0-unstable-2026-07-27 ``                                            |
| [`f94b086d`](https://github.com/NixOS/nixpkgs/commit/f94b086d4797969a12b5be493c0f477a94b9a27d) | `` weaver: 0.25.0 -> 0.25.1 ``                                                                                  |
| [`cb99623b`](https://github.com/NixOS/nixpkgs/commit/cb99623b8f792e6f67f0288c76cad473baa4a398) | `` river: 0.4.5 -> 0.4.6 ``                                                                                     |
| [`2a7b9221`](https://github.com/NixOS/nixpkgs/commit/2a7b92216db6bc97d09dc41e098392b29e5cb106) | `` river: modernize ``                                                                                          |
| [`7269a8b6`](https://github.com/NixOS/nixpkgs/commit/7269a8b61908fde8bf1571208215b91dcb8110b3) | `` gtk-engine-murrine: remove ``                                                                                |
| [`6597b98a`](https://github.com/NixOS/nixpkgs/commit/6597b98a22794a5101eda1c81706670beab37ea7) | `` zuki-themes: remove ``                                                                                       |
| [`39915321`](https://github.com/NixOS/nixpkgs/commit/399153218eaf897c6f286327ad91d8faddae5699) | `` yaru-theme: remove ``                                                                                        |
| [`bcdf2b8c`](https://github.com/NixOS/nixpkgs/commit/bcdf2b8cacfcbaf7334e1d14d70ba36375e5fc63) | `` vimix-gtk-themes: remove ``                                                                                  |
| [`f54c31af`](https://github.com/NixOS/nixpkgs/commit/f54c31afa30862d16fca75ff718108fe4c001553) | `` venta: remove ``                                                                                             |
| [`b0855da5`](https://github.com/NixOS/nixpkgs/commit/b0855da503f162443bc4627fd109dc60fc6df076) | `` ubuntu-themes: remove ``                                                                                     |
| [`e2e5ee0c`](https://github.com/NixOS/nixpkgs/commit/e2e5ee0c6193a9caaaaf79000299435f3f79c3d3) | `` mint-x-icons: drop dependency on ubuntu-themes ``                                                            |
| [`659574ec`](https://github.com/NixOS/nixpkgs/commit/659574ec9405f015bfdf35bd258e586b00d9f7fc) | `` tokyonight-gtk-theme: remove ``                                                                              |
| [`3d99521b`](https://github.com/NixOS/nixpkgs/commit/3d99521b002585d0db81df14adf116bb0b18ed9e) | `` theme-vertex: remove ``                                                                                      |
| [`d71e788e`](https://github.com/NixOS/nixpkgs/commit/d71e788e429eff29276e411237d04f00519356a1) | `` theme-obsidian2: remove ``                                                                                   |
| [`ed4144c3`](https://github.com/NixOS/nixpkgs/commit/ed4144c38d2590577453ab160f792a6ecffe633c) | `` theme-jade1: remove ``                                                                                       |
| [`2af5c1bd`](https://github.com/NixOS/nixpkgs/commit/2af5c1bd4f60bab1e22c9d0759708b2c83e578ca) | `` sweet: remove ``                                                                                             |
| [`20102116`](https://github.com/NixOS/nixpkgs/commit/201021167b1625e7d183934721a72378253d9ed6) | `` stilo-themes: remove ``                                                                                      |
| [`dab58795`](https://github.com/NixOS/nixpkgs/commit/dab5879597564d357b72bd149f15276a53b6044b) | `` solarc-gtk-theme: remove ``                                                                                  |
| [`4d650d83`](https://github.com/NixOS/nixpkgs/commit/4d650d831866e8c50d846fffde6fe7822c72fdde) | `` snowblind: remove ``                                                                                         |
| [`7b20f935`](https://github.com/NixOS/nixpkgs/commit/7b20f93597c0d194387989a017efb266bc14f632) | `` sierra-gtk-theme: remove ``                                                                                  |
| [`43abc16a`](https://github.com/NixOS/nixpkgs/commit/43abc16a03cf64ac776d5d276916a1c053fb24cb) | `` rose-pine-gtk-theme: remove ``                                                                               |
| [`196b94d2`](https://github.com/NixOS/nixpkgs/commit/196b94d22f265af1b9f0a19543348e7e48974c0c) | `` qogir-theme: remove ``                                                                                       |
| [`ca34f7f7`](https://github.com/NixOS/nixpkgs/commit/ca34f7f7270397f3e2c4517136e650581009e59a) | `` pop-gtk-theme: remove ``                                                                                     |
| [`c634c2d0`](https://github.com/NixOS/nixpkgs/commit/c634c2d00d62c40128f0a27a0aa232cc07205bdc) | `` plata-theme: remove ``                                                                                       |
| [`755ad0a7`](https://github.com/NixOS/nixpkgs/commit/755ad0a777d2423f8daface5f4004e32dbe310f9) | `` plano-theme: remove ``                                                                                       |
| [`376d9eec`](https://github.com/NixOS/nixpkgs/commit/376d9eec93f8c48ec85c18ab083c7436a644ee14) | `` orchis-theme: remove ``                                                                                      |
| [`74213d21`](https://github.com/NixOS/nixpkgs/commit/74213d21a8d8af39272743556394810b6d7aec05) | `` omni-gtk-theme: remove ``                                                                                    |
| [`a512da36`](https://github.com/NixOS/nixpkgs/commit/a512da365cb4a72a90520e99ab2bf9a3f2a4e141) | `` numix-sx-gtk-theme: remove ``                                                                                |
| [`4537c2da`](https://github.com/NixOS/nixpkgs/commit/4537c2da155dc75e3d42dcf8c11c9799c33c76f3) | `` numix-solarized-gtk-theme: remove ``                                                                         |
| [`9d8d039f`](https://github.com/NixOS/nixpkgs/commit/9d8d039fa42b408dd8c2eaad2732a8bf2a0ef175) | `` numix-gtk-theme: remove ``                                                                                   |
| [`6b579784`](https://github.com/NixOS/nixpkgs/commit/6b579784d561fdc643e91c644687b95602eb4bb4) | `` nordic: remove ``                                                                                            |
| [`93a9713d`](https://github.com/NixOS/nixpkgs/commit/93a9713d3b5455f7ec679afd1fe0725aa638688a) | `` nightfox-gtk-theme: remove ``                                                                                |
| [`02bbbca2`](https://github.com/NixOS/nixpkgs/commit/02bbbca294946633512853882f858987836426a8) | `` mojave-gtk-theme: remove ``                                                                                  |
| [`80570166`](https://github.com/NixOS/nixpkgs/commit/80570166b795df1e5f2dac196b05c727ad62ef9a) | `` matrix-gtk-theme: remove ``                                                                                  |
| [`55776f4f`](https://github.com/NixOS/nixpkgs/commit/55776f4f39d94cc3b9f5e2499cee63b7b4f575a0) | `` mate-themes: remove ``                                                                                       |
| [`7873ecce`](https://github.com/NixOS/nixpkgs/commit/7873ecce441f38a67316eb6b9e976ef88c154def) | `` materia-theme-transparent: remove ``                                                                         |
| [`ecd317db`](https://github.com/NixOS/nixpkgs/commit/ecd317db5284dad1d739c6a43b61481ef04a87a1) | `` materia-theme: remove ``                                                                                     |
| [`f8afb852`](https://github.com/NixOS/nixpkgs/commit/f8afb852839ddf764392d3154693ed2e7a794933) | `` matcha-gtk-theme: remove ``                                                                                  |
| [`3e499be1`](https://github.com/NixOS/nixpkgs/commit/3e499be1deb331b4de9183560b7e4fb7cf28e68d) | `` marwaita-yellow: remove ``                                                                                   |
| [`9623ce08`](https://github.com/NixOS/nixpkgs/commit/9623ce089536b74f9f8b73fd6eca01fe0219e86f) | `` marwaita-x: remove ``                                                                                        |
| [`145d7c88`](https://github.com/NixOS/nixpkgs/commit/145d7c888ccf7b375cdc31f5c8a9147c855602b0) | `` marwaita-teal: remove ``                                                                                     |
| [`17456048`](https://github.com/NixOS/nixpkgs/commit/17456048b1d4bd0a08984311f328a78dd433485f) | `` marwaita-red: remove ``                                                                                      |
| [`c73d5e61`](https://github.com/NixOS/nixpkgs/commit/c73d5e6109e5c819de0834344a6a8266dfe371e5) | `` marwaita: remove ``                                                                                          |
| [`48584d76`](https://github.com/NixOS/nixpkgs/commit/48584d76a2e9b5c1196a11ed2d568bef078d4f73) | `` marwaita-orange: remove ``                                                                                   |
| [`56e3d00d`](https://github.com/NixOS/nixpkgs/commit/56e3d00d67662f460880f3bce6ad1bb67144011b) | `` marwaita-mint: remove ``                                                                                     |
| [`ce5d2038`](https://github.com/NixOS/nixpkgs/commit/ce5d2038330a3196a1f0f7dc6d0664e0671bf4fc) | `` magnetic-catppuccin-gtk: remove ``                                                                           |
| [`e14abc58`](https://github.com/NixOS/nixpkgs/commit/e14abc58066b2f3de678aabc2cb36a67c2cfe0ad) | `` lounge-gtk-theme: remove ``                                                                                  |
| [`ec165b31`](https://github.com/NixOS/nixpkgs/commit/ec165b31ec600a05f5d2fc869a5b87773af9650e) | `` layan-gtk-theme: remove ``                                                                                   |
| [`7fb43cc4`](https://github.com/NixOS/nixpkgs/commit/7fb43cc4bec0d7635316114b07aebb0d0f610d03) | `` lavanda-gtk-theme: remove ``                                                                                 |
| [`35baacb4`](https://github.com/NixOS/nixpkgs/commit/35baacb4eda08de2c3b62b2da1ee361c5097ba85) | `` kanagawa-gtk-theme: remove ``                                                                                |
| [`dfb5b9f8`](https://github.com/NixOS/nixpkgs/commit/dfb5b9f8e6a4b6584b27c11e3e70ebd6a63c602c) | `` jasper-gtk-theme: remove ``                                                                                  |
| [`73a4182e`](https://github.com/NixOS/nixpkgs/commit/73a4182e7b967ac6bce90669c63933267c7c23db) | `` gruvbox-material-gtk-theme: remove ``                                                                        |
| [`20282c92`](https://github.com/NixOS/nixpkgs/commit/20282c9248eeb8671b6163c2cb2573b28b60619d) | `` gruvbox-gtk-theme: remove ``                                                                                 |
| [`f2690890`](https://github.com/NixOS/nixpkgs/commit/f2690890bd925de60efc0c221e1bc62e72d82aa3) | `` greybird: remove ``                                                                                          |
| [`2604a1bb`](https://github.com/NixOS/nixpkgs/commit/2604a1bbe590a584dab9f6f48fa24448810cfc80) | `` graphite-gtk-theme: remove ``                                                                                |
| [`1f5996fd`](https://github.com/NixOS/nixpkgs/commit/1f5996fd40228f5958b40022af6dcc60a568ddd5) | `` fluent-gtk-theme: remove ``                                                                                  |
| [`4be0a7c2`](https://github.com/NixOS/nixpkgs/commit/4be0a7c2e9fe18b71d36ac0c48d39f59c95fde81) | `` flat-remix-gtk: remove ``                                                                                    |
| [`4a68b971`](https://github.com/NixOS/nixpkgs/commit/4a68b971401e27eaffcbf82a5b9501d0e6db0383) | `` everforest-gtk-theme: remove ``                                                                              |
| [`e204fe50`](https://github.com/NixOS/nixpkgs/commit/e204fe5014e1b6299b414ed36e8cde8c2ba39d31) | `` equilux-theme: remove ``                                                                                     |
| [`1cebb71a`](https://github.com/NixOS/nixpkgs/commit/1cebb71aca1161f59e9db2fa9ca02c73e4dcd0b1) | `` dracula-theme: remove ``                                                                                     |
| [`30cfe3e1`](https://github.com/NixOS/nixpkgs/commit/30cfe3e11977b6b2e040d9aacf910419a06f1f7b) | `` colloid-gtk-theme: remove ``                                                                                 |
| [`045406e3`](https://github.com/NixOS/nixpkgs/commit/045406e3c55a6aaf08171eda5ecb2ef9daff0d4d) | `` canta-theme: remove ``                                                                                       |
| [`7dca1064`](https://github.com/NixOS/nixpkgs/commit/7dca10648709fd0d3f4163452f2876d208f6c57e) | `` blackbird: remove ``                                                                                         |
| [`7a3aa95b`](https://github.com/NixOS/nixpkgs/commit/7a3aa95b7bcf2958c05b51329d5daafd6d7e6547) | `` ayu-theme-gtk: remove ``                                                                                     |
| [`3d175adf`](https://github.com/NixOS/nixpkgs/commit/3d175adfa0acf07bfdaf343c57077d586f69a319) | `` arc-theme: remove ``                                                                                         |
| [`4d4196ea`](https://github.com/NixOS/nixpkgs/commit/4d4196eae193366141dab2fc99331df07aeb8267) | `` ant-theme: remove ``                                                                                         |
| [`b54ba3a4`](https://github.com/NixOS/nixpkgs/commit/b54ba3a468f5ab84f35c729651a2426efe256f2f) | `` ant-nebula-theme: remove ``                                                                                  |
| [`90dffaec`](https://github.com/NixOS/nixpkgs/commit/90dffaec1e8152083cf7a161a01a26b72e99b535) | `` ant-bloody-theme: remove ``                                                                                  |
| [`88809b5e`](https://github.com/NixOS/nixpkgs/commit/88809b5e8c9b7c1c7eb7b4d38a851cc02d3d13cf) | `` andromeda-gtk-theme: remove ``                                                                               |
| [`3355a9d2`](https://github.com/NixOS/nixpkgs/commit/3355a9d2f5e14ef8ee0f526cd078e3ba94c7c75e) | `` amber-theme: remove ``                                                                                       |
| [`f291f0ec`](https://github.com/NixOS/nixpkgs/commit/f291f0ec1fc1e6d990637500654dc57e58a49735) | `` adapta-gtk-theme: remove ``                                                                                  |
| [`de7ff4ce`](https://github.com/NixOS/nixpkgs/commit/de7ff4ce25df2b1437584acd14fd98c9b7367cff) | `` dnscontrol: 4.43.0 -> 4.44.1 ``                                                                              |
| [`e314e0ac`](https://github.com/NixOS/nixpkgs/commit/e314e0acf5ed93fdd3f061acac99ff1c66d93885) | `` diffyml: 1.7.1 -> 1.8.0 ``                                                                                   |
| [`5d673155`](https://github.com/NixOS/nixpkgs/commit/5d673155aafbb36b56ea498bfd6f425c204dce6a) | `` python3Packages.optuna: skip failing tests ``                                                                |
| [`6de3e22d`](https://github.com/NixOS/nixpkgs/commit/6de3e22dd4a251af62263716c3b49240871c42c2) | `` markdownlint-cli2: 0.23.1 -> 0.23.2 ``                                                                       |
| [`55bf2ba3`](https://github.com/NixOS/nixpkgs/commit/55bf2ba3bd5c48ec329f97d5a03d8660ea7eae10) | `` edac-utils: fix version, add __structuredAttrs ``                                                            |
| [`c04f0227`](https://github.com/NixOS/nixpkgs/commit/c04f02275221acfc238dd15191cb58cb7ae4614a) | `` frankenphp: 1.12.5 -> 1.12.6 ``                                                                              |
| [`a55e2185`](https://github.com/NixOS/nixpkgs/commit/a55e2185dd8ee0cd628034af14e45e37a4ef8148) | `` metasploit: 6.4.144 -> 6.4.146 ``                                                                            |
| [`ffc86d2a`](https://github.com/NixOS/nixpkgs/commit/ffc86d2a938da1dee84b77befad10c388f798f20) | `` kontainer: 1.5.0 -> 1.5.2 ``                                                                                 |
| [`8f6456e3`](https://github.com/NixOS/nixpkgs/commit/8f6456e397ba074abc8e5c33305e3af5316dfe32) | `` home-assistant-custom-components.battery_notes: 3.4.8 -> 3.5.1 ``                                            |
| [`a08e8537`](https://github.com/NixOS/nixpkgs/commit/a08e8537fd4c9710b5b88d94de04fa250e415167) | `` google-chrome: 150.0.7871.186 -> 151.0.7922.71 ``                                                            |
| [`c1c1e95c`](https://github.com/NixOS/nixpkgs/commit/c1c1e95cf41a62852fe1518bc866c1cfbbeafaac) | `` kulala-core: 0.28.2 -> 0.30.0 ``                                                                             |
| [`992bd1ba`](https://github.com/NixOS/nixpkgs/commit/992bd1bab61305168eefa1ec7ee387ccd2db0025) | `` aws-sso-cli: 2.3.1 -> 2.3.2 ``                                                                               |
| [`c5d92f89`](https://github.com/NixOS/nixpkgs/commit/c5d92f89c062ac13d446f6a022dfa56a6a6e4f57) | `` cargo-tally: 1.0.75 -> 1.0.76 ``                                                                             |
| [`d1f1d4d8`](https://github.com/NixOS/nixpkgs/commit/d1f1d4d87f096aec3f1c890d13e1c69d39eb8a32) | `` buildkit: 0.31.2 -> 0.32.0 ``                                                                                |
| [`99a63495`](https://github.com/NixOS/nixpkgs/commit/99a63495fcce0aa07b6468ba7e5876f3ddb80497) | `` namecoind: 31.0 -> 31.1 ``                                                                                   |
| [`2bed2920`](https://github.com/NixOS/nixpkgs/commit/2bed292047fd2ea50100707c44aae63d7ea13dc8) | `` python3Packages.keras: 3.15.0 -> 3.15.1 ``                                                                   |
| [`624345a4`](https://github.com/NixOS/nixpkgs/commit/624345a49ec2969d1aa6329358483d8a0ffc13a4) | `` python3Packages.simple-parsing: 0.1.8 -> 0.1.9 ``                                                            |
| [`b6933988`](https://github.com/NixOS/nixpkgs/commit/b69339883e48382e6269342838aaddba367fc168) | `` mullvad-vpn: add desktop icons, minor improvements ``                                                        |
| [`8dd979fe`](https://github.com/NixOS/nixpkgs/commit/8dd979fe72c87171aa867de45a63454d8998196d) | `` onnxruntime: fix cuda build ``                                                                               |
| [`4c5f5eca`](https://github.com/NixOS/nixpkgs/commit/4c5f5ecab7566e4a3b33c1ead82e6481cedb23ca) | `` panache: 3.0.0 -> 3.0.2 ``                                                                                   |
| [`049be4f3`](https://github.com/NixOS/nixpkgs/commit/049be4f3fe6aa501057e1f592e6efe7f44ca705d) | `` gitsign: 0.16.1 -> 0.17.0 ``                                                                                 |
| [`3e148f1e`](https://github.com/NixOS/nixpkgs/commit/3e148f1e4cf625e258706f812f873938389c374e) | `` google-java-format: 1.35.0 -> 1.36.0 ``                                                                      |
| [`8390853f`](https://github.com/NixOS/nixpkgs/commit/8390853f4148fb7b5ded9feda56d7aee0fde3884) | `` pgscv: 0.15.2 -> 0.15.3 ``                                                                                   |
| [`36c0328d`](https://github.com/NixOS/nixpkgs/commit/36c0328dfd51578a44fbcac3a80c7ff626529091) | `` python3Packages.scanpy: 1.12.2 -> 1.12.3 ``                                                                  |
| [`ee9b97cb`](https://github.com/NixOS/nixpkgs/commit/ee9b97cb844b19f80ce7dfdc81f2b521a0dcabde) | `` rucio: 40.4.1 -> 41.1.0 ``                                                                                   |
| [`6cd34bed`](https://github.com/NixOS/nixpkgs/commit/6cd34bed1c9fb90d91a4d88515beca5d803d039a) | `` python3Packages.array-api-compat: 1.14 -> 1.15 ``                                                            |
| [`b78b88b4`](https://github.com/NixOS/nixpkgs/commit/b78b88b4347392a7b37e17664966feb75e439c67) | `` mdbook-katex: 0.9.4 -> 0.10.0 ``                                                                             |
| [`3f8c8fd9`](https://github.com/NixOS/nixpkgs/commit/3f8c8fd95629d1d6b97088680e30776e3615628e) | `` dawarich: bump rails to 8.1.3.1 to fix CVE-2026-66066 ``                                                     |
| [`ea36ce2c`](https://github.com/NixOS/nixpkgs/commit/ea36ce2caf709000ed26b18342c92cf055fde1a8) | `` pnpm: 11.17.0 -> 11.18.0 ``                                                                                  |
| [`af81341f`](https://github.com/NixOS/nixpkgs/commit/af81341f98afd2cb7848c22be328730a99fa3256) | `` ledger-live-desktop: 4.11.0 -> 4.13.0 ``                                                                     |
| [`4f6e51a7`](https://github.com/NixOS/nixpkgs/commit/4f6e51a7e7450069197a5fbcb461cf44561de699) | `` go-swagger: 0.35.1 -> 0.35.3 ``                                                                              |
| [`9c37a127`](https://github.com/NixOS/nixpkgs/commit/9c37a1276e63fc3e2be5e37e3441a3994a97be17) | `` sonarqube-cli: 1.3.0.3493 -> 1.4.0.3748 ``                                                                   |
| [`5482002f`](https://github.com/NixOS/nixpkgs/commit/5482002f056a0e1260b794366cc84f8f4e7d1ee7) | `` mesa: 26.1.5 -> 26.1.6 ``                                                                                    |
| [`2a75d0d8`](https://github.com/NixOS/nixpkgs/commit/2a75d0d8f312b955971e28d426dd6df13365a288) | `` vcluster: add shell completion files ``                                                                      |
| [`efbe2994`](https://github.com/NixOS/nixpkgs/commit/efbe29944774ac097a0d24b371b488b78976586f) | `` python3Packages.pycaption: 2.2.28 -> 2.3.1 ``                                                                |
| [`fc6181cb`](https://github.com/NixOS/nixpkgs/commit/fc6181cbaaf8b13d2bf1a9033dbee7084496b1bc) | `` opencode{,-desktop}: 1.18.4 -> 1.18.9 ``                                                                     |
| [`c3b97d33`](https://github.com/NixOS/nixpkgs/commit/c3b97d3302cbfd7cfa00a78012509eee92f9b87a) | `` tail-tray: 0.2.33 -> 0.2.34 ``                                                                               |
| [`71de8953`](https://github.com/NixOS/nixpkgs/commit/71de89537dba3b9f1b7b546a5144ba20e33fb33d) | `` services.kanidm: fix broken link in description ``                                                           |
| [`1921e99d`](https://github.com/NixOS/nixpkgs/commit/1921e99d30bc710f3b2a5b9c5762bd811f846158) | `` python3Packages.lmstudio: fix build ``                                                                       |
| [`ec93d96f`](https://github.com/NixOS/nixpkgs/commit/ec93d96fe64e54e70284af9a57c2e7e757b943c6) | `` nodejs_22: 22.23.1 -> 22.23.2 ``                                                                             |
| [`9ca948bd`](https://github.com/NixOS/nixpkgs/commit/9ca948bd74ece83b548ac41534f16e6f9475433c) | `` nodejs_26: 26.5.0 -> 26.5.1 ``                                                                               |
| [`c7699f75`](https://github.com/NixOS/nixpkgs/commit/c7699f75426310612dc8e99770249ae96b9f8641) | `` emacs.pkgs.ghostel: 0.47 -> 0.48 ``                                                                          |
| [`3d6c8c4b`](https://github.com/NixOS/nixpkgs/commit/3d6c8c4b06c1eec9578ff288916c86cda91755ad) | `` tf: 2.13.0 -> 2.14.1 ``                                                                                      |
| [`0846427e`](https://github.com/NixOS/nixpkgs/commit/0846427e6dd546f25444128b201392458598f5ac) | `` renode-dts2repl: 0-unstable-2026-07-20 -> 0-unstable-2026-07-27 ``                                           |
| [`dc4be957`](https://github.com/NixOS/nixpkgs/commit/dc4be957075ee6a0e61465291cf36df49c565ff1) | `` mission-center: 1.1.0 -> 1.2.0 ``                                                                            |
| [`65c673b3`](https://github.com/NixOS/nixpkgs/commit/65c673b399543e9a7fa009444b2aa3296b52d90f) | `` noxdir: 1.2.1 -> 1.2.2 ``                                                                                    |
| [`072c1d92`](https://github.com/NixOS/nixpkgs/commit/072c1d92dacbc93ae39df150c7ddb29fb6a1bdaa) | `` librewolf-unwrapped: 152.0-3 -> 153.0.1-1 ``                                                                 |
| [`74ebe61d`](https://github.com/NixOS/nixpkgs/commit/74ebe61de7e3944f0ac063664d4ea8cb5f0b6905) | `` python3Packages.rerun-sdk: fix build ``                                                                      |
| [`ecb3f923`](https://github.com/NixOS/nixpkgs/commit/ecb3f923f1ac731319c378e18bdb3cc40fcda9ba) | `` openocd-adi: 0.12.0-1.3.1-2 -> 0.12.0-1.4.0 ``                                                               |
| [`30ee585c`](https://github.com/NixOS/nixpkgs/commit/30ee585c02df97c9c7309016db09f865c059c876) | `` moon: 2.3.2 -> 2.4.6 ``                                                                                      |
| [`ece1f6d9`](https://github.com/NixOS/nixpkgs/commit/ece1f6d92ff5f6a19a9c1adb2387c89757d2af29) | `` python3Packages.mysql-connector-python: 9.7.0 -> 26.7.0 ``                                                   |
| [`59868574`](https://github.com/NixOS/nixpkgs/commit/59868574d077a9ceb5f522f358830ae1e84dcde4) | `` mcat-unwrapped: 0.6.2 -> 0.6.3 ``                                                                            |
| [`a4f17278`](https://github.com/NixOS/nixpkgs/commit/a4f172781ef0dd9d27b963efccf1512ce11c06d8) | `` ankiAddons.ajt-card-management: 25.10.14.0 -> 26.2.21.0 ``                                                   |
| [`619ca58e`](https://github.com/NixOS/nixpkgs/commit/619ca58e86b010fb61f98d3cf39b0a37b4fd89a7) | `` crossplane-cli: 2.4.0 -> 2.4.1 ``                                                                            |
| [`90043fc8`](https://github.com/NixOS/nixpkgs/commit/90043fc879ea74d02813e14aba7e3c776146b073) | `` cargo-arc: 0.2.2 -> 0.3.0 ``                                                                                 |
| [`b3ee76e2`](https://github.com/NixOS/nixpkgs/commit/b3ee76e2a1cf378a3497e0e16ee5e9dc3ac3acdc) | `` fetchYarnDeps: set impureEnvVars ``                                                                          |
| [`b283f0d1`](https://github.com/NixOS/nixpkgs/commit/b283f0d111b11953aeb64725681dff6e03067bbe) | `` xdg-desktop-portal-cosmic: 1.4.0 -> 1.5.0 ``                                                                 |
| [`cb477d7c`](https://github.com/NixOS/nixpkgs/commit/cb477d7c294b5c6b6a3e16361c5127a9d88b9a19) | `` cosmic-workspaces-epoch: 1.4.0 -> 1.5.0 ``                                                                   |
| [`11ed6f43`](https://github.com/NixOS/nixpkgs/commit/11ed6f43e5c43c0600d68d7c241d0852a2625bb8) | `` cosmic-wallpapers: 1.4.0 -> 1.5.0 ``                                                                         |
| [`7bf43099`](https://github.com/NixOS/nixpkgs/commit/7bf430998cf0e9874a533b2eaf1310b5a98f8eae) | `` cosmic-term: 1.4.0 -> 1.5.0 ``                                                                               |
| [`628833f7`](https://github.com/NixOS/nixpkgs/commit/628833f7abac637018e9de7aa3cbc9eaeac6f34e) | `` cosmic-store: 1.4.0 -> 1.5.0 ``                                                                              |
| [`ba6117f1`](https://github.com/NixOS/nixpkgs/commit/ba6117f184fe4e08fc651046cb83658388ce8428) | `` cosmic-sound-theme: 1.4.0 -> 1.5.0 ``                                                                        |
| [`b952aab9`](https://github.com/NixOS/nixpkgs/commit/b952aab93607414375f0456daad1c214d407298e) | `` cosmic-settings-daemon: 1.4.0 -> 1.5.0 ``                                                                    |
| [`90fb03d6`](https://github.com/NixOS/nixpkgs/commit/90fb03d6929eed720b19880b1226ff32cf838200) | `` cosmic-settings: 1.4.0 -> 1.5.0 ``                                                                           |
| [`00d3af1c`](https://github.com/NixOS/nixpkgs/commit/00d3af1c294ab76e0848054c99e3f8915a0de71a) | `` cosmic-session: 1.4.0 -> 1.5.0 ``                                                                            |
| [`2c678ec7`](https://github.com/NixOS/nixpkgs/commit/2c678ec7a468ec7021c08bf9bf85f8edbb9430fd) | `` cosmic-screenshot: 1.4.0 -> 1.5.0 ``                                                                         |
| [`bd95ed95`](https://github.com/NixOS/nixpkgs/commit/bd95ed950f24fdcec29394881ed45b35b344ab44) | `` cosmic-reader: 0-unstable-2026-06-06 -> 0-unstable-2026-07-28 ``                                             |
| [`ef6ebe27`](https://github.com/NixOS/nixpkgs/commit/ef6ebe27781e714f9c6913d4d0b32b22df53bdea) | `` cosmic-randr: 1.4.0 -> 1.5.0 ``                                                                              |
| [`c7429b4b`](https://github.com/NixOS/nixpkgs/commit/c7429b4ba5e7c95a42c18e335dfcb8787630939b) | `` cosmic-player: 1.4.0 -> 1.5.0 ``                                                                             |
| [`12b05823`](https://github.com/NixOS/nixpkgs/commit/12b05823a2f53db7a602d8f78b81711e939696c9) | `` cosmic-panel: 1.4.0 -> 1.5.0 ``                                                                              |
| [`5f5f0c4b`](https://github.com/NixOS/nixpkgs/commit/5f5f0c4b730e1abdf6d4ef67e86d76a19944bb2d) | `` cosmic-osd: 1.4.0 -> 1.5.0 ``                                                                                |
| [`d56ba8d1`](https://github.com/NixOS/nixpkgs/commit/d56ba8d18100a07257d1ab485526a875c8c64c53) | `` cosmic-notifications: 1.4.0 -> 1.5.0 ``                                                                      |
| [`83c66d6b`](https://github.com/NixOS/nixpkgs/commit/83c66d6bbb3290c5b3aa96e2f5b23777db8ff3cc) | `` cosmic-monitor: 1.4.0 -> 1.5.0 ``                                                                            |
| [`8265675d`](https://github.com/NixOS/nixpkgs/commit/8265675df2dfd3f852c78981352a64a247a6d6cb) | `` cosmic-launcher: 1.4.0 -> 1.5.0 ``                                                                           |
| [`3ea04898`](https://github.com/NixOS/nixpkgs/commit/3ea0489838e70ba2fccc5114f3a286eda549979c) | `` cosmic-initial-setup: 1.4.0 -> 1.5.0 ``                                                                      |
| [`a777d974`](https://github.com/NixOS/nixpkgs/commit/a777d9743ed34d7c636e3d2c35153fdba7390bdc) | `` cosmic-idle: 1.4.0 -> 1.5.0 ``                                                                               |
| [`efd9bac3`](https://github.com/NixOS/nixpkgs/commit/efd9bac3c00aba59c39275a73050bd6b3e4c0dbc) | `` cosmic-icons: 1.4.0 -> 1.5.0 ``                                                                              |
| [`217a53ff`](https://github.com/NixOS/nixpkgs/commit/217a53ff29ac00fab4c3cacec406ec8863ffde9e) | `` cosmic-greeter: 1.4.0 -> 1.5.0 ``                                                                            |
| [`71f0336d`](https://github.com/NixOS/nixpkgs/commit/71f0336dc76212a5646e4a56cf8b254b3048b101) | `` cosmic-files: 1.4.0 -> 1.5.0 ``                                                                              |
| [`17f21991`](https://github.com/NixOS/nixpkgs/commit/17f219918e9f4136514da01007c06fcffd9bc477) | `` cosmic-edit: 1.4.0 -> 1.5.0 ``                                                                               |
| [`8447da86`](https://github.com/NixOS/nixpkgs/commit/8447da862c09b9a04436d2953143a1a7bdc247c0) | `` cosmic-comp: 1.4.0 -> 1.5.0 ``                                                                               |
| [`338bd1ec`](https://github.com/NixOS/nixpkgs/commit/338bd1ec7e9dc64ca9dc236b338958695c4eb34c) | `` cosmic-bg: 1.4.0 -> 1.5.0 ``                                                                                 |
| [`363b2668`](https://github.com/NixOS/nixpkgs/commit/363b266887d9007b076707d449612b06769df007) | `` cosmic-app-library: 1.4.0 -> 1.5.0 ``                                                                        |
| [`821dabe3`](https://github.com/NixOS/nixpkgs/commit/821dabe32ba7e6bd026cd41764e78e1b8bc3c66b) | `` cosmic-applets: 1.4.0 -> 1.5.0 ``                                                                            |
| [`6ffe49bd`](https://github.com/NixOS/nixpkgs/commit/6ffe49bd584f1baf81d8f0550604cccde66b669d) | `` libretro.flycast: 0-unstable-2026-07-10 -> 0-unstable-2026-07-21 ``                                          |
| [`82500abb`](https://github.com/NixOS/nixpkgs/commit/82500abba9421c3ca991affeb372519dc1533963) | `` gitlab: 18.11.7 -> 19.0.4 ``                                                                                 |
| [`2e2e3946`](https://github.com/NixOS/nixpkgs/commit/2e2e394667121793c13e70b3fcf4ec1685a8b982) | `` gitlab-container-registry: 4.39.0 -> 4.40.2 ``                                                               |
| [`3f015b91`](https://github.com/NixOS/nixpkgs/commit/3f015b9124423c494e7c658536e94709919fe6c2) | `` nixos/gitlab: introduce seperate module for container registry ``                                            |
| [`2eff50a1`](https://github.com/NixOS/nixpkgs/commit/2eff50a1281f27b1ac5f97129df69a7bb2d47c21) | `` postgresqlPackages.pg_partman: 5.4.3 -> 5.5.0 ``                                                             |
| [`2647fe1c`](https://github.com/NixOS/nixpkgs/commit/2647fe1c9cead38aabd8839841277d4e7fad98ac) | `` gleam: 1.17.0 -> 1.18.0 ``                                                                                   |
| [`2cb89c75`](https://github.com/NixOS/nixpkgs/commit/2cb89c75e2899781591a3c5c285c316492827557) | `` plasticscm-client-core-unwrapped: 11.0.16.10216 -> 11.0.16.10303 ``                                          |

*... and 5052 more commits (truncated)*