### PR TITLE
ci: fix hadolint findings and enable the hadolint pre-commit hook

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -184,9 +184,14 @@ RUN set -xe && \
 # Stage 2: Runtime image
 # ============================================================
 FROM ghcr.io/sdr-enthusiasts/docker-baseimage:base
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ARG BUILD_NUMBER=0
+
+# SHELL must come *after* any ARG/ENV in the stage. hadolint 2.15.x resets its
+# shell-dialect tracking to POSIX sh when an ARG or ENV follows SHELL, which
+# makes every later RUN be linted as sh and spuriously reports SC3054 for the
+# bash arrays below.
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Copy the Node.js runtime from the builder.
 # node:slim is Debian-based (same ABI family as docker-baseimage:base) so the

--- a/Dockerfile
+++ b/Dockerfile
@@ -312,4 +312,4 @@ ENV ENABLE_ACARS="false" \
     IMSL_CONNECTIONS="udp" \
     IRDM_CONNECTIONS="udp"
 
-HEALTHCHECK --start-period=3600s --interval=600s CMD /scripts/healthcheck.sh
+HEALTHCHECK --start-period=3600s --interval=600s CMD ["/scripts/healthcheck.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,15 @@ COPY acarshub-types/ ./acarshub-types/
 # Re-declare ARG after FROM so it is in scope for the RUN
 ARG BUILD_NUMBER=0
 
+# VITE_BUILD_NUMBER is a compile-time Vite variable, inlined into the frontend
+# bundle by `vite build` (see acarshub-react/src/utils/version.ts). It is
+# declared as ENV rather than exported inside a single RUN because the build is
+# split across several RUN layers below (WORKDIR instead of `cd`, per DL3003),
+# and a shell `export` would not survive across them. This is a builder stage,
+# so the variable never reaches the runtime image.
+ENV VITE_BUILD_NUMBER="${BUILD_NUMBER}"
+
 RUN set -xe && \
-    export VITE_BUILD_NUMBER="${BUILD_NUMBER}" && \
     # Build each workspace individually so we can skip generate-sprites for the
     # React app.  The sprite sheets (PNG + WebP) are pre-generated static assets
     # committed to the repository (acarshub-react/src/assets/sprites/) and are
@@ -67,8 +74,18 @@ RUN set -xe && \
     # dependency on sharp's native binary running correctly under QEMU emulation,
     # and avoids re-triggering the issue if the lockfile is ever corrupted again.
     # `vite build` produces an identical dist/ output without touching sharp.
-    npm run build --workspace=@acarshub/types && \
-    cd acarshub-react && npx vite build && cd .. && \
+    npm run build --workspace=@acarshub/types
+
+# `vite build` is invoked directly (not via `npm run build --workspace`) to skip
+# generate-sprites, per the rationale above. WORKDIR rather than `cd` satisfies
+# DL3003; the following WORKDIR returns to /workspace because the remaining
+# staging steps use paths relative to the workspace root.
+WORKDIR /workspace/acarshub-react
+RUN set -xe && \
+    npx vite build
+
+WORKDIR /workspace
+RUN set -xe && \
     npm run build --workspace=@acarshub/backend && \
     # Bundle the backend into a single ESM file with esbuild.
     # better-sqlite3 and zeromq are marked external because they contain native

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -50,11 +50,13 @@ COPY acarshub-backend/ ./acarshub-backend/
 # present in acarshub-react/src/assets/sprites/ and rebuilding them
 # would require sharp's native binary under emulation (see main
 # Dockerfile for the full history of why this is avoided).
-RUN npm run build --workspace=@acarshub/types && \
-    cd acarshub-react && VITE_E2E=true npx vite build
+RUN npm run build --workspace=@acarshub/types
 
-# ── Test runner ──────────────────────────────────────────────
+# WORKDIR rather than `cd` satisfies DL3003. This is also the directory the
+# Playwright runner needs below, so it is set once and serves both purposes.
 WORKDIR /work/acarshub-react
+
+RUN VITE_E2E=true npx vite build
 
 # PLAYWRIGHT_DOCKER=true enables Firefox, WebKit, and Mobile browser
 # projects in playwright.config.ts.  These are gated behind this flag

--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,7 @@
           src = ./.;
 
           check_javascript = true;
+          check_docker = true;
           check_python = false;
 
           javascript = {


### PR DESCRIPTION
## Problem

This repo has **four** hadolint findings, of which only two come from the 2.15.x rule changes. None are currently visible, because `check_docker` was never set — it defaults to `false` in the shared ruleset (`FredSystems/pre-commit-checks`, `check_docker ? false`), so the generated pre-commit config carried no `hadolint` hook and the Dockerfiles were never linted at all.

| Finding | Where | New in 2.15.x? |
|----------|--------------------------------------|----------------|
| DL3003 | `Dockerfile:50`, `Dockerfile.e2e:53` | **No** — fires on the pinned 2.14.0 too |
| SC3054 | `Dockerfile:188` | Yes — upstream regression |
| DL3025 | `Dockerfile:293` | Yes — `HEALTHCHECK` coverage added |

Unlike the sibling PRs in this series, there is no unpinned `hadolint` job in the deploy workflow here, so nothing was going to break a deploy. The exposure is the `Lint` job on every PR, the moment `flake.lock` picks up hadolint 2.15.x — plus the two DL3003 findings that would surface immediately on enabling the hook.

## Changes

Four commits, ordered so that hadolint is clean at the **pinned** version from the first commit onward, and the hook is only switched on once 2.15.1 is clean as well.

### `refactor: use WORKDIR instead of cd in build stages`

`cd` inside a `RUN` dies with that `RUN`'s shell; `WORKDIR` persists to every later instruction *and* into `Config.WorkingDir`. Both sites are in builder stages, so nothing reaches the runtime image.

`Dockerfile` — the single build `RUN` is split into three:

```diff
-    npm run build --workspace=@acarshub/types && \
-    cd acarshub-react && npx vite build && cd .. && \
-    npm run build --workspace=@acarshub/backend && \
+    npm run build --workspace=@acarshub/types
+
+WORKDIR /workspace/acarshub-react
+RUN set -xe && \
+    npx vite build
+
+WORKDIR /workspace
+RUN set -xe && \
+    npm run build --workspace=@acarshub/backend && \
```

The `WORKDIR` returns to `/workspace` because the remaining staging steps use paths relative to the workspace root (`./acarshub-react/dist/*`, `./acarshub-backend/drizzle/`, `node_modules/...`).

The `RUN` previously began `export VITE_BUILD_NUMBER="${BUILD_NUMBER}"`, which would **not survive the split** — the frontend would silently build with an empty build number and nothing would fail. It becomes an `ENV` so `vite build` still receives it. `VITE_BUILD_NUMBER` is consumed only by `vite build` (`import.meta.env.VITE_BUILD_NUMBER`, see `acarshub-react/src/utils/version.ts:66`), and stage 1 is discarded, so it does not reach the runtime image.

`Dockerfile.e2e` — the `cd` was the last command in its `RUN`, and the file already set `WORKDIR /work/acarshub-react` immediately afterwards, so that `WORKDIR` simply moves up and now serves both the build and the Playwright runner.

The literal `ARG BUILD_NUMBER=0` lines are deliberately untouched: `deploy.yml` rewrites them via `sed 's/ARG BUILD_NUMBER=0/.../'` to inject the CI run number, and all three occurrences still match.

### `fix: move ARG above SHELL to avoid spurious SC3054`

hadolint 2.15.x resets its shell-dialect tracking to POSIX sh when an `ARG` or `ENV` follows `SHELL` in the same stage, so later `RUN`s are linted as sh and the bash arrays are reported as undefined. Minimal reproduction:

```dockerfile
FROM debian:trixie-slim
SHELL ["/bin/bash", "-o", "pipefail", "-c"]
ARG FOO="bar"
RUN P=() && P+=(nginx) && echo "${P[@]}"
```

```text
2.15.1 -> SC3054 warning: In POSIX sh, array references are undefined.
2.14.0 -> rc=0
```

Moving the `ARG` above `SHELL` restores correct tracking, and is inert: `ARG` scope runs from declaration to end of stage either way, and `SHELL` does not consume it. Confirmed `--build-arg` propagates identically with the declaration on either side.

Preferred over `# hadolint ignore=SC3054`, which would suppress the whole POSIX-portability class on that `RUN`. The upstream bug is wider than SC3054 — `SC3010`, `SC3009`, `SC3028` and `SC3037` all misfire the same way — so fixing the ordering is the durable choice.

### `fix: use JSON exec form for HEALTHCHECK CMD`

```diff
-HEALTHCHECK --start-period=3600s --interval=600s CMD /scripts/healthcheck.sh
+HEALTHCHECK --start-period=3600s --interval=600s CMD ["/scripts/healthcheck.sh"]
```

### `ci: enable the shared hadolint pre-commit hook`

`check_docker = true`, so `just ci` actually lints the Dockerfiles. Last in the series, so no intermediate commit turns `Lint` red.

## Verification

### The image is equivalent

Built `main` and this branch and compared. This was the point of concern, since splitting a `RUN` adds layers:

```text
                   main            this branch
size               348254216       348254216
rootfs_layers      19              19
Config.WorkingDir  "/backend"      "/backend"
Config.Entrypoint  ["/init"]       ["/init"]
Config.Env         identical       identical
VITE_BUILD_NUMBER  absent          absent
Healthcheck.Test   ["CMD-SHELL",…] ["CMD",…]
```

**Identical size and identical layer count** — the extra builder-stage layers do not ship, and `WORKDIR` layers are 0 B metadata regardless. Only `Test[0]` differs.

All staged artifacts hash-identical:

```text
server.bundle.mjs      274bbdff…  ==  274bbdff…
migrate-worker.mjs     87bb1742…  ==  87bb1742…
drizzle_tree_hash      52a2fcd2…  ==  52a2fcd2…
addon_deps_tree_hash   b31563d1…  ==  b31563d1…
webapp_dist_file_count 126        ==  126
```

`/webapp/dist` had two classes of difference, both traced to **pre-existing per-build nondeterminism**, not this change:

- **44 `.gz` files** — produced in stage 2 by `gzip -9 --keep`, which stores the source mtime in its header. Byte 5-8 differ (`95 56 72 6a` vs `ad 56 72 6a`); **all 44 decompress to identical bytes**.
- **`stats.html`** — `rollup-plugin-visualizer` emits random uids (`"uid":"33f0c612-1"` vs `"uid":"a676edf8-1"`). Confirmed pre-existing by running `vite build` twice from identical source in one container: `c48e0f65…` then `93b679a4…`.

Every other file in `/webapp/dist` is identical, and the file list matches exactly.

### Lint

`nix develop -c bash -c 'npm i && just ci'` — green, ending in `✅ All checks passed!`, with `hadolint` now present in the hook run (it was absent before this branch, which is the direct evidence the `check_docker` flip took effect).

Per commit, so `git bisect` stays usable:

```text
SHA       2.14.0  2.15.1  pc-hadolint  subject
d2e1ba08  rc=0    rc=1    false        refactor: use WORKDIR instead of cd in build stages
aaffd9e1  rc=0    rc=1    false        fix: move ARG above SHELL to avoid spurious SC3054
1b6c14e1  rc=0    rc=0    false        fix: use JSON exec form for HEALTHCHECK CMD
f86ffe20  rc=0    rc=0    true         ci: enable the shared hadolint pre-commit hook
```

`rc=0` at the pinned version for every commit; 2.15.1 clean by the time the hook is enabled. No hooks bypassed; no `--no-verify`.
