### PR TITLE
fix(alerts): keep Mark All Read reachable at every viewport

### DIFF
--- a/acarshub-backend/package.json
+++ b/acarshub-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acarshub/backend",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "ACARS Hub Node.js backend server",
   "type": "module",
   "main": "./dist/server.js",

--- a/acarshub-react/e2e/alerts-action-placement.spec.ts
+++ b/acarshub-react/e2e/alerts-action-placement.spec.ts
@@ -1,0 +1,445 @@
+import { expect, type Page, test } from "@playwright/test";
+
+// ---------------------------------------------------------------------------
+// alerts-action-placement.spec.ts
+//
+// Purpose
+// -------
+// Regression suite for the Alerts page's "Mark All Read" action remaining
+// visible and correctly anchored at every viewport.
+//
+// The bug this guards against: `.page__header` is hidden by
+// `@media (max-height: 800px)`, which took the Mark All Read button with it.
+// Hiding the header is intended — hiding the action is not. The action now
+// relocates to one of three homes depending on viewport (see
+// hooks/useAlertActionPlacement.ts).
+//
+// Why this needs to be E2E rather than a unit test
+// ------------------------------------------------
+// The failure mode is *visual*, not structural: the button is present in the
+// DOM in every case; what breaks is whether an ancestor is `display: none`,
+// whether it is clipped out of the nav bar, or whether it overlaps the
+// msg/min widget. jsdom has no layout engine and reports every element as
+// visible with a zero-sized box, so only a real browser can catch it. Unit
+// coverage of the placement *rule* lives in
+// src/hooks/__tests__/useAlertActionPlacement.test.ts.
+//
+// This spec runs viewport-driven assertions and therefore overrides the
+// project viewport per test rather than relying on the project matrix.
+// ---------------------------------------------------------------------------
+
+const MIN_TOUCH = 44;
+
+interface MinimalAcarsMsg {
+  uid: string;
+  message_type: string;
+  timestamp: number;
+  station_id: string;
+  flight?: string;
+  tail?: string;
+  text?: string;
+  label?: string;
+  matched?: boolean;
+  matched_text?: string[];
+}
+
+const ALERT_MSG: MinimalAcarsMsg = {
+  uid: "placement-alert-1",
+  message_type: "acars",
+  timestamp: 1_700_000_000,
+  station_id: "TEST",
+  flight: "UAL123",
+  tail: "N12345",
+  text: "EMERGENCY placement fixture",
+  label: "H1",
+  matched: true,
+  matched_text: ["UAL123"],
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function injectAlertTerms(page: Page, terms: string[]): Promise<boolean> {
+  return page.evaluate((termList) => {
+    return new Promise<boolean>((resolve) => {
+      const deadline = Date.now() + 5000;
+      const tryInject = () => {
+        // biome-ignore lint/suspicious/noExplicitAny: Required for E2E testing window access
+        const store = (window as any).__ACARS_STORE__;
+        if (store) {
+          store.getState().setAlertTerms({ terms: termList, ignore: [] });
+          resolve(true);
+        } else if (Date.now() >= deadline) {
+          resolve(false);
+        } else {
+          setTimeout(tryInject, 50);
+        }
+      };
+      tryInject();
+    });
+  }, terms);
+}
+
+async function injectAlertMessage(
+  page: Page,
+  msg: MinimalAcarsMsg,
+): Promise<boolean> {
+  return page.evaluate((message) => {
+    return new Promise<boolean>((resolve) => {
+      const deadline = Date.now() + 5000;
+      const tryInject = () => {
+        // biome-ignore lint/suspicious/noExplicitAny: Required for E2E testing window access
+        const store = (window as any).__ACARS_STORE__;
+        if (store) {
+          store.getState().addAlertMessage(message);
+          resolve(true);
+        } else if (Date.now() >= deadline) {
+          resolve(false);
+        } else {
+          setTimeout(tryInject, 50);
+        }
+      };
+      tryInject();
+    });
+  }, msg);
+}
+
+/**
+ * Loads the app at the given viewport, seeds one unread alert, and navigates
+ * to the Alerts page via client-side routing.
+ *
+ * The viewport is set BEFORE the first paint so the placement hook's initial
+ * matchMedia read is already correct — resizing afterwards would exercise the
+ * (separately tested) resize path instead of the cold-load path most users
+ * actually hit.
+ */
+async function gotoAlertsAt(
+  page: Page,
+  width: number,
+  height: number,
+): Promise<void> {
+  await page.setViewportSize({ width, height });
+  await page.goto("/");
+  await expect(page.locator("header.navigation")).toBeVisible();
+
+  expect(await injectAlertTerms(page, ["UAL123"])).toBe(true);
+  expect(await injectAlertMessage(page, ALERT_MSG)).toBe(true);
+
+  const mobileMenu = page.locator("details.small_nav");
+  if (await mobileMenu.isVisible()) {
+    await page.locator("details.small_nav > summary").click();
+  }
+
+  await Promise.all([
+    page.waitForURL(/\/alerts/, { timeout: 15000 }),
+    page
+      .getByRole("link", { name: /^alerts/i })
+      .first()
+      .click(),
+  ]);
+
+  // Always-visible content-area anchor (the header may be hidden here).
+  await expect(page.locator(".alerts-page__mode-toggle")).toBeVisible();
+}
+
+const markAllRead = (page: Page) =>
+  page.getByRole("button", { name: /mark all read/i });
+
+// ---------------------------------------------------------------------------
+// The placement matrix
+//
+// Each row is a real device/window shape mapped to the placement it must
+// resolve to. Thresholds: header hidden at height <= 800px; nav-slot below
+// 768px width.
+// ---------------------------------------------------------------------------
+
+interface PlacementCase {
+  label: string;
+  width: number;
+  height: number;
+  placement: "page-header" | "controls-bar" | "nav-slot";
+}
+
+const CASES: PlacementCase[] = [
+  // --- Tall viewports: header visible, action stays in it -------------------
+  {
+    label: "desktop 1080p",
+    width: 1920,
+    height: 1080,
+    placement: "page-header",
+  },
+  { label: "laptop tall", width: 1280, height: 900, placement: "page-header" },
+  {
+    label: "tablet portrait",
+    width: 768,
+    height: 1024,
+    placement: "page-header",
+  },
+  {
+    label: "phone portrait tall",
+    width: 390,
+    height: 844,
+    placement: "page-header",
+  },
+  {
+    label: "height boundary 801",
+    width: 1280,
+    height: 801,
+    placement: "page-header",
+  },
+
+  // --- Short + wide: header gone, action moves to the mode row --------------
+  {
+    label: "height boundary 800",
+    width: 1280,
+    height: 800,
+    placement: "controls-bar",
+  },
+  { label: "laptop 720p", width: 1280, height: 720, placement: "controls-bar" },
+  {
+    label: "tablet landscape",
+    width: 1024,
+    height: 768,
+    placement: "controls-bar",
+  },
+  {
+    label: "width boundary 768",
+    width: 768,
+    height: 720,
+    placement: "controls-bar",
+  },
+  {
+    label: "phone landscape wide",
+    width: 844,
+    height: 390,
+    placement: "controls-bar",
+  },
+
+  // --- Short + narrow: header gone and no room on the mode row --------------
+  {
+    label: "width boundary 767",
+    width: 767,
+    height: 720,
+    placement: "nav-slot",
+  },
+  { label: "phone landscape", width: 667, height: 375, placement: "nav-slot" },
+  {
+    label: "phone portrait short",
+    width: 390,
+    height: 664,
+    placement: "nav-slot",
+  },
+  { label: "small phone", width: 320, height: 568, placement: "nav-slot" },
+];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe("Alerts — Mark All Read placement", () => {
+  for (const { label, width, height, placement } of CASES) {
+    test(`${label} (${width}x${height}) → ${placement}`, async ({ page }) => {
+      await gotoAlertsAt(page, width, height);
+
+      const button = markAllRead(page);
+
+      // 1. Visible. This is the entire point of the feature — at no viewport
+      //    may the action be unreachable.
+      await expect(button).toBeVisible();
+
+      // 2. Resolved to the expected placement.
+      await expect(button).toHaveAttribute("data-placement", placement);
+
+      // 3. Exactly one instance — never duplicated across placements.
+      await expect(button).toHaveCount(1);
+
+      // 4. Anchored in the correct container.
+      if (placement === "page-header") {
+        await expect(
+          page.locator(".page__header .alerts-page__mark-read-button"),
+        ).toBeVisible();
+      } else if (placement === "controls-bar") {
+        await expect(
+          page.locator(".alerts-page__mode-row .alerts-page__mark-read-button"),
+        ).toBeVisible();
+      } else {
+        await expect(
+          page.locator(
+            ".mobile_nav_action_slot .alerts-page__mark-read-button",
+          ),
+        ).toBeVisible();
+      }
+
+      // 5. Actually within the viewport, not merely "not display:none".
+      //    A control pushed off the right edge of the nav bar satisfies
+      //    toBeVisible() but is unusable.
+      const box = await button.boundingBox();
+      expect(box).not.toBeNull();
+      if (box) {
+        expect(box.x).toBeGreaterThanOrEqual(0);
+        expect(box.y).toBeGreaterThanOrEqual(0);
+        expect(box.x + box.width).toBeLessThanOrEqual(width + 1);
+        expect(box.y + box.height).toBeLessThanOrEqual(height + 1);
+      }
+
+      // 6. Clickable, and the click reaches the handler. Portalled content in
+      //    particular could be visually present but covered by the nav's
+      //    stacking context.
+      await button.click();
+      await expect(button).toHaveCount(0); // hidden once nothing is unread
+    });
+  }
+
+  test("action does not overlap the msg/min widget in the nav slot", async ({
+    page,
+  }) => {
+    // The nav-slot placement shares a phone-width line with the message-rate
+    // widget. Overlap here would mean one of them is unreadable.
+    await gotoAlertsAt(page, 700, 500);
+
+    const button = markAllRead(page);
+    await expect(button).toHaveAttribute("data-placement", "nav-slot");
+
+    const rate = page.locator(".message-rate");
+    // The widget is itself hidden below 375px width; only compare when shown.
+    if (await rate.isVisible()) {
+      const rateBox = await rate.boundingBox();
+      const btnBox = await button.boundingBox();
+      expect(rateBox).not.toBeNull();
+      expect(btnBox).not.toBeNull();
+      if (rateBox && btnBox) {
+        // Button sits to the right of the widget, with no horizontal overlap.
+        expect(btnBox.x).toBeGreaterThanOrEqual(rateBox.x + rateBox.width - 1);
+      }
+    }
+  });
+
+  test("controls-bar action is exactly as tall as the mode buttons", async ({
+    page,
+  }) => {
+    // The action sits on the same row as Live/Historical. Any height
+    // difference between them reads as a misalignment bug rather than as
+    // deliberate visual hierarchy.
+    //
+    // Enforced by align-self:stretch in SCSS rather than by duplicating the
+    // mode button's metrics, so this test is what catches a future padding
+    // change on either element silently decoupling the two.
+    await gotoAlertsAt(page, 1280, 720);
+
+    const button = markAllRead(page);
+    await expect(button).toHaveAttribute("data-placement", "controls-bar");
+
+    const liveButton = page
+      .locator(".alerts-page__mode-button")
+      .filter({ hasText: /^Live$/ });
+
+    const actionBox = await button.boundingBox();
+    const modeBox = await liveButton.boundingBox();
+    expect(actionBox).not.toBeNull();
+    expect(modeBox).not.toBeNull();
+
+    if (actionBox && modeBox) {
+      // Sub-pixel rounding is tolerable; anything more is visible.
+      expect(Math.abs(actionBox.height - modeBox.height)).toBeLessThanOrEqual(
+        1,
+      );
+
+      // Same height is necessary but not sufficient — they must also share a
+      // baseline, otherwise equal boxes can still sit vertically offset.
+      expect(Math.abs(actionBox.y - modeBox.y)).toBeLessThanOrEqual(1);
+    }
+  });
+
+  test("controls-bar action still meets the 44px touch floor", async ({
+    page,
+  }) => {
+    // Matching the mode buttons is only correct if the mode buttons are
+    // themselves >= 44px. Pin that, so a future shrink of the mode button
+    // cannot quietly drag the action below the touch floor with it.
+    await gotoAlertsAt(page, 768, 720);
+
+    const button = markAllRead(page);
+    await expect(button).toHaveAttribute("data-placement", "controls-bar");
+
+    const box = await button.boundingBox();
+    expect(box).not.toBeNull();
+    if (box) {
+      expect(box.height).toBeGreaterThanOrEqual(MIN_TOUCH);
+    }
+  });
+
+  test("nav-slot action keeps a 44px touch target", async ({ page }) => {
+    // SCSS-TOUCH: the nav placement trims horizontal padding to fit, which is
+    // exactly the kind of change that quietly breaks the vertical touch floor.
+    await gotoAlertsAt(page, 390, 664);
+
+    const button = markAllRead(page);
+    await expect(button).toHaveAttribute("data-placement", "nav-slot");
+
+    const box = await button.boundingBox();
+    expect(box).not.toBeNull();
+    if (box) {
+      expect(box.height).toBeGreaterThanOrEqual(MIN_TOUCH);
+    }
+  });
+
+  test("action follows the viewport when it is resized live", async ({
+    page,
+  }) => {
+    // Users rotate phones and drag window edges; the action must re-home
+    // without a reload and without ever being duplicated mid-transition.
+    await gotoAlertsAt(page, 1280, 900);
+
+    const button = markAllRead(page);
+    await expect(button).toHaveAttribute("data-placement", "page-header");
+
+    await page.setViewportSize({ width: 1280, height: 700 });
+    await expect(button).toHaveAttribute("data-placement", "controls-bar");
+    await expect(button).toBeVisible();
+    await expect(button).toHaveCount(1);
+
+    await page.setViewportSize({ width: 500, height: 700 });
+    await expect(button).toHaveAttribute("data-placement", "nav-slot");
+    await expect(button).toBeVisible();
+    await expect(button).toHaveCount(1);
+
+    await page.setViewportSize({ width: 500, height: 900 });
+    await expect(button).toHaveAttribute("data-placement", "page-header");
+    await expect(button).toBeVisible();
+    await expect(button).toHaveCount(1);
+  });
+
+  test("action leaves the nav slot when navigating away from Alerts", async ({
+    page,
+  }) => {
+    // The portal escapes the page subtree, so an unmount bug would strand the
+    // button in the nav bar on every other page.
+    await gotoAlertsAt(page, 390, 664);
+    await expect(markAllRead(page)).toBeVisible();
+
+    await page.locator("details.small_nav > summary").click();
+    await Promise.all([
+      page.waitForURL(/\/live-messages/, { timeout: 15000 }),
+      page
+        .getByRole("link", { name: /^messages/i })
+        .first()
+        .click(),
+    ]);
+
+    await expect(markAllRead(page)).toHaveCount(0);
+    await expect(page.locator(".mobile_nav_action_slot")).toBeEmpty();
+  });
+
+  test("historical mode has no action at any placement", async ({ page }) => {
+    // Historical results carry no read state; a lingering button would be a
+    // no-op control, and in the nav slot it would look like a global action.
+    await gotoAlertsAt(page, 390, 664);
+    await expect(markAllRead(page)).toBeVisible();
+
+    await page.getByRole("button", { name: /^historical$/i }).click();
+
+    await expect(markAllRead(page)).toHaveCount(0);
+    await expect(page.locator(".mobile_nav_action_slot")).toBeEmpty();
+  });
+});

--- a/acarshub-react/e2e/page-header-consistency.spec.ts
+++ b/acarshub-react/e2e/page-header-consistency.spec.ts
@@ -1,0 +1,109 @@
+import { expect, type Page, test } from "@playwright/test";
+
+// ---------------------------------------------------------------------------
+// page-header-consistency.spec.ts
+//
+// Purpose
+// -------
+// Pins the vertical chrome above each page's content to be consistent across
+// the tool surfaces.
+//
+// The bug this guards against: `.page` used to carry a top margin
+// ($spacing-sm / $spacing-lg) by default. Every app-like page overrode it back
+// to 0 — Live Messages and Alerts explicitly, Stats via `margin: 0 auto auto
+// auto`, Live Map via `margin: 0 !important` — except Search, which was simply
+// never given the override. Search therefore rendered a 24px gap above its
+// header that no other tool page had, inflating its apparent header area by
+// roughly 45% (77px of chrome vs 57px elsewhere).
+//
+// The default is now 0 and About opts in, which is the inverse of the previous
+// arrangement and matches what the majority of pages actually want.
+//
+// Why E2E: the defect is a *computed* margin on a shared base class
+// interacting with per-page overrides across five stylesheets. Only a real
+// cascade can tell you what a given page ends up with.
+// ---------------------------------------------------------------------------
+
+/**
+ * Tool surfaces: pages that are monitored rather than read, and which
+ * therefore sit flush against the nav bar to preserve vertical space.
+ *
+ * Live Map is excluded — it is full-viewport and renders no `.page__header`.
+ */
+const TOOL_PAGES = [
+  { name: "Live Messages", path: "/live-messages" },
+  { name: "Alerts", path: "/alerts" },
+  { name: "Search Database", path: "/search" },
+  { name: "Stats", path: "/status" },
+] as const;
+
+/**
+ * Measures the gap between the bottom of the nav bar and the top of the
+ * page header.
+ *
+ * Uses a full page load per route rather than client-side navigation: the
+ * measurement must reflect the page's own styles from a cold start, and
+ * SPA transitions can leave the previous route's `.page` element in the DOM
+ * for a frame.
+ */
+async function gapAboveHeader(page: Page, path: string): Promise<number> {
+  await page.goto(path, { waitUntil: "load" });
+  await page.locator(".page__header").first().waitFor({ state: "visible" });
+
+  return page.evaluate(() => {
+    const app = document.querySelector(".app-content");
+    const header = document.querySelector(".page__header");
+    if (!app || !header) throw new Error("missing .app-content/.page__header");
+    return Math.round(
+      header.getBoundingClientRect().top - app.getBoundingClientRect().top,
+    );
+  });
+}
+
+test.describe("page header vertical chrome", () => {
+  test.describe("tool pages sit flush against the nav bar", () => {
+    for (const { name, path } of TOOL_PAGES) {
+      test(`${name} has no gap above its header`, async ({ page }) => {
+        await page.setViewportSize({ width: 1280, height: 900 });
+        expect(await gapAboveHeader(page, path)).toBe(0);
+      });
+
+      test(`${name} has no gap above its header on mobile`, async ({
+        page,
+      }) => {
+        await page.setViewportSize({ width: 390, height: 900 });
+        expect(await gapAboveHeader(page, path)).toBe(0);
+      });
+    }
+  });
+
+  test("every tool page has the same gap above its header", async ({
+    page,
+  }) => {
+    // The absolute value is asserted above; this pins them equal to each
+    // other, which is the property a user actually perceives when moving
+    // between pages. Written as a set comparison so a future change that
+    // moves all of them together stays green while one drifting fails.
+    await page.setViewportSize({ width: 1280, height: 900 });
+
+    const gaps = new Map<string, number>();
+    for (const { name, path } of TOOL_PAGES) {
+      gaps.set(name, await gapAboveHeader(page, path));
+    }
+
+    expect(
+      new Set(gaps.values()).size,
+      `gaps differ: ${JSON.stringify(Object.fromEntries(gaps))}`,
+    ).toBe(1);
+  });
+
+  test("About keeps its deliberate detachment from the nav bar", async ({
+    page,
+  }) => {
+    // About is a document rather than a tool surface and opts in to a gap.
+    // Asserted so the opt-in is not silently lost in a future cleanup of the
+    // `.page` margin rules.
+    await page.setViewportSize({ width: 1280, height: 900 });
+    expect(await gapAboveHeader(page, "/about")).toBeGreaterThan(0);
+  });
+});

--- a/acarshub-react/package.json
+++ b/acarshub-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acarshub-react",
   "private": true,
-  "version": "4.2.1",
+  "version": "4.2.2",
   "type": "module",
   "homepage": ".",
   "scripts": {

--- a/acarshub-react/src/components/Navigation.tsx
+++ b/acarshub-react/src/components/Navigation.tsx
@@ -25,6 +25,8 @@ import {
   useAppStore,
 } from "../store/useAppStore";
 import type { MessageRateData } from "../types";
+import { MOBILE_NAV_QUERY } from "../utils/breakpoints";
+import { registerNavActionSlot } from "../utils/navActionSlot";
 import { scrollToTop } from "../utils/scrollRegistry";
 import { MessageFilters } from "./MessageFilters";
 
@@ -146,7 +148,7 @@ export const Navigation = () => {
   const systemHasError = useAppStore(selectSystemErrorState);
   const setSettingsOpen = useAppStore((state) => state.setSettingsOpen);
   const menuDetailsRef = useRef<HTMLDetailsElement>(null);
-  const isMobile = useMediaQuery("(max-width: 767px)");
+  const isMobile = useMediaQuery(MOBILE_NAV_QUERY);
 
   // Filter flyout state (for Live Messages page)
   const [filtersOpen, setFiltersOpen] = useState(false);
@@ -193,6 +195,29 @@ export const Navigation = () => {
       menuDetailsRef.current.open = false;
     }
   };
+
+  /**
+   * Ref callback for the mobile nav's page-action slot.
+   *
+   * WHY a callback ref rather than useRef + useEffect: the slot element is
+   * mounted and unmounted by the `isMobile` branch below, and a callback ref
+   * fires during the same commit as that structural change. An effect would
+   * publish the element one commit late, and — worse — on the mobile→desktop
+   * transition would leave the registry briefly holding a detached node that a
+   * page could still portal into.
+   *
+   * React 19 invokes the returned cleanup on detach, so deregistration is
+   * automatic and cannot be missed. `useCallback` with an empty dep list keeps
+   * the ref identity stable, preventing React from tearing down and
+   * re-registering the slot on every unrelated nav re-render (of which there
+   * are many — the msg/min widget updates every few seconds).
+   */
+  const navActionSlotRef = useCallback((el: HTMLDivElement | null) => {
+    registerNavActionSlot(el);
+    return () => {
+      registerNavActionSlot(null);
+    };
+  }, []);
 
   /**
    * Desktop active-nav-link click handler.
@@ -280,8 +305,22 @@ export const Navigation = () => {
               )}
             </div>
 
-            {/* Message rate widget — pinned to right edge of mobile nav */}
-            <MessageRateWidget />
+            {/* Right group: msg/min widget, then the page action slot.
+                Grouped in a flex row so both stay pinned to the right edge
+                under the container's space-between. */}
+            <div className="mobile_nav_right">
+              <MessageRateWidget />
+
+              {/*
+                Page action slot.
+                Kept empty by Navigation itself — the active page portals its
+                single highest-priority action in here via useNavActionSlot()
+                when the viewport leaves it nowhere else to go. See
+                utils/navActionSlot.ts for why the page pushes rather than the
+                nav pulling. Renders as a zero-width no-op when unoccupied.
+              */}
+              <div className="mobile_nav_action_slot" ref={navActionSlotRef} />
+            </div>
           </nav>
         ) : (
           /* Desktop menu */

--- a/acarshub-react/src/components/__tests__/Navigation.test.tsx
+++ b/acarshub-react/src/components/__tests__/Navigation.test.tsx
@@ -74,6 +74,10 @@ import { act, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  _resetNavActionSlotForTesting,
+  getNavActionSlot,
+} from "../../utils/navActionSlot";
 import { scrollToTop } from "../../utils/scrollRegistry";
 // SUT and scrollRegistry imports below are intentionally placed after the
 // vi.mock blocks for readability. Biome's organize-imports rule would
@@ -523,6 +527,81 @@ describe("Navigation", () => {
       expect(button).toHaveAttribute("aria-expanded", "true");
       await user.click(button);
       expect(button).toHaveAttribute("aria-expanded", "false");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Page action slot
+  //
+  // The mobile nav exposes one slot that the active page portals a
+  // high-priority action into (Alerts' "Mark All Read" when the page header is
+  // hidden at phone width). Navigation's responsibility is only to mount the
+  // slot on mobile and publish it to the registry — it never populates it.
+  // -------------------------------------------------------------------------
+
+  describe("page action slot", () => {
+    afterEach(() => {
+      _resetNavActionSlotForTesting();
+    });
+
+    it("mounts the slot on mobile and registers it", () => {
+      mockMediaQueryResult.current = true;
+      renderAt("/about");
+
+      const slot = document.querySelector(".mobile_nav_action_slot");
+      expect(slot).toBeInTheDocument();
+      expect(getNavActionSlot()).toBe(slot);
+    });
+
+    it("does not mount or register a slot on desktop", () => {
+      // At desktop width pages have room for their own actions, so there is
+      // deliberately nothing to portal into.
+      mockMediaQueryResult.current = false;
+      renderAt("/about");
+
+      expect(
+        document.querySelector(".mobile_nav_action_slot"),
+      ).not.toBeInTheDocument();
+      expect(getNavActionSlot()).toBeNull();
+    });
+
+    it("leaves the slot empty — Navigation never populates it", () => {
+      mockMediaQueryResult.current = true;
+      renderAt("/alerts");
+
+      expect(
+        document.querySelector(".mobile_nav_action_slot"),
+      ).toBeEmptyDOMElement();
+    });
+
+    it("deregisters the slot on unmount", () => {
+      // A stale registration would let a page portal into a detached node,
+      // silently losing the action.
+      mockMediaQueryResult.current = true;
+      const { unmount } = renderAt("/about");
+      expect(getNavActionSlot()).not.toBeNull();
+
+      unmount();
+
+      expect(getNavActionSlot()).toBeNull();
+    });
+
+    it("registers the slot alongside the message-rate widget in the right group", () => {
+      // Placement matters: the slot must sit after the msg/min widget inside
+      // the right-hand group so both stay pinned to the right edge.
+      mockMediaQueryResult.current = true;
+      renderAt("/about", {
+        messageRate: makeRate({ total: 12 }),
+        decoders: makeDecoders({ acars: true }),
+      });
+
+      const right = document.querySelector(".mobile_nav_right");
+      expect(right).toBeInTheDocument();
+
+      const children = Array.from(right?.children ?? []);
+      expect(children).toHaveLength(2);
+      expect(children[0]).toHaveClass("message-rate");
+      expect(children[1]).toHaveClass("mobile_nav_action_slot");
     });
   });
 });

--- a/acarshub-react/src/hooks/__tests__/useAlertActionPlacement.test.ts
+++ b/acarshub-react/src/hooks/__tests__/useAlertActionPlacement.test.ts
@@ -1,0 +1,191 @@
+// Copyright (C) 2022-2026 Frederick Clausen II
+// This file is part of acarshub <https://github.com/sdr-enthusiasts/docker-acarshub>.
+
+// acarshub is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// acarshub is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with acarshub.  If not, see <http://www.gnu.org/licenses/>.
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAlertActionPlacement } from "../useAlertActionPlacement";
+
+// ---------------------------------------------------------------------------
+// matchMedia harness
+//
+// jsdom's matchMedia stub (see test/setup.ts) always reports matches:false and
+// ignores the query, so it cannot express "short but wide". This harness
+// evaluates the two queries the hook actually uses against a viewport the test
+// controls, and supports live changes so the resize path is covered too.
+// ---------------------------------------------------------------------------
+
+interface Viewport {
+  width: number;
+  height: number;
+}
+
+type ChangeListener = (event: MediaQueryListEvent) => void;
+
+let viewport: Viewport = { width: 1280, height: 900 };
+const listeners = new Set<{ query: string; fn: ChangeListener }>();
+
+/**
+ * Evaluates the subset of media query syntax this hook uses. Deliberately
+ * narrow: if the hook ever starts using a query shape this does not
+ * understand, the throw makes that loud rather than silently returning false
+ * and producing a green but meaningless test.
+ */
+function evaluate(query: string, vp: Viewport): boolean {
+  const maxWidth = query.match(/^\(max-width:\s*(\d+)px\)$/);
+  if (maxWidth) return vp.width <= Number(maxWidth[1]);
+
+  const maxHeight = query.match(/^\(max-height:\s*(\d+)px\)$/);
+  if (maxHeight) return vp.height <= Number(maxHeight[1]);
+
+  throw new Error(`Unsupported media query in test harness: ${query}`);
+}
+
+function setViewport(next: Viewport): void {
+  viewport = next;
+  for (const l of listeners) {
+    // Real matchMedia hands the listener a MediaQueryListEvent carrying the
+    // new match state, and useMediaQuery reads event.matches from it. Passing
+    // a bare call would leave the hook reading undefined.
+    l.fn({
+      matches: evaluate(l.query, viewport),
+      media: l.query,
+    } as MediaQueryListEvent);
+  }
+}
+
+beforeEach(() => {
+  viewport = { width: 1280, height: 900 };
+  listeners.clear();
+
+  vi.stubGlobal(
+    "matchMedia",
+    (query: string): MediaQueryList =>
+      ({
+        get matches() {
+          return evaluate(query, viewport);
+        },
+        media: query,
+        onchange: null,
+        addEventListener: (_: string, fn: ChangeListener) => {
+          listeners.add({ query, fn });
+        },
+        removeEventListener: (_: string, fn: ChangeListener) => {
+          for (const l of listeners) {
+            if (l.fn === fn) listeners.delete(l);
+          }
+        },
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      }) as unknown as MediaQueryList,
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const placementAt = (width: number, height: number): string => {
+  viewport = { width, height };
+  return renderHook(() => useAlertActionPlacement()).result.current;
+};
+
+describe("useAlertActionPlacement", () => {
+  describe("header visible (viewport height > 800px)", () => {
+    it.each([
+      ["desktop", 1920, 1080],
+      ["laptop", 1280, 900],
+      ["tablet portrait", 768, 1024],
+      // The header is hidden by a *height* query alone, so a narrow-but-tall
+      // phone in portrait keeps the header — and therefore keeps the action
+      // in it, rather than relocating to the nav bar.
+      ["phone portrait", 390, 844],
+      ["narrow phone portrait", 320, 900],
+    ])("uses page-header on %s (%ix%i)", (_label, width, height) => {
+      expect(placementAt(width, height)).toBe("page-header");
+    });
+  });
+
+  describe("header hidden (viewport height <= 800px)", () => {
+    it.each([
+      ["desktop short", 1920, 720],
+      ["laptop short", 1280, 720],
+      ["tablet landscape", 1024, 768],
+      ["md boundary", 768, 720],
+    ])("uses controls-bar on %s (%ix%i)", (_label, width, height) => {
+      expect(placementAt(width, height)).toBe("controls-bar");
+    });
+
+    it.each([
+      ["just below md", 767, 720],
+      ["phone landscape", 844, 390], // wide enough for controls-bar
+    ])("resolves %s (%ix%i) by width", (_label, width, height) => {
+      const expected = width <= 767 ? "nav-slot" : "controls-bar";
+      expect(placementAt(width, height)).toBe(expected);
+    });
+
+    it.each([
+      ["phone landscape narrow", 667, 375],
+      ["phone portrait short", 390, 664],
+      ["small phone", 320, 568],
+    ])("uses nav-slot on %s (%ix%i)", (_label, width, height) => {
+      expect(placementAt(width, height)).toBe("nav-slot");
+    });
+  });
+
+  describe("boundary pixels", () => {
+    // These four assertions are the whole point of deriving the thresholds
+    // from a shared module: an off-by-one puts the action in a hidden
+    // container at exactly one viewport size, which no coarse-grained test
+    // would ever visit.
+    it("keeps page-header at exactly 801px height", () => {
+      expect(placementAt(1280, 801)).toBe("page-header");
+    });
+
+    it("switches away from page-header at exactly 800px height", () => {
+      expect(placementAt(1280, 800)).toBe("controls-bar");
+    });
+
+    it("uses controls-bar at exactly 768px width when the header is hidden", () => {
+      expect(placementAt(768, 800)).toBe("controls-bar");
+    });
+
+    it("uses nav-slot at exactly 767px width when the header is hidden", () => {
+      expect(placementAt(767, 800)).toBe("nav-slot");
+    });
+  });
+
+  describe("reacting to viewport changes", () => {
+    it("moves the action as the viewport is resized across both axes", () => {
+      viewport = { width: 1280, height: 900 };
+      const { result } = renderHook(() => useAlertActionPlacement());
+      expect(result.current).toBe("page-header");
+
+      // Shrink height only: header goes away, width still roomy.
+      act(() => setViewport({ width: 1280, height: 700 }));
+      expect(result.current).toBe("controls-bar");
+
+      // Shrink width too: no room on the mode row, fall back to the nav bar.
+      act(() => setViewport({ width: 500, height: 700 }));
+      expect(result.current).toBe("nav-slot");
+
+      // Restore height: the header returns and reclaims the action even
+      // though the viewport is still narrow.
+      act(() => setViewport({ width: 500, height: 900 }));
+      expect(result.current).toBe("page-header");
+    });
+  });
+});

--- a/acarshub-react/src/hooks/__tests__/useNavActionSlot.test.ts
+++ b/acarshub-react/src/hooks/__tests__/useNavActionSlot.test.ts
@@ -1,0 +1,92 @@
+// Copyright (C) 2022-2026 Frederick Clausen II
+// This file is part of acarshub <https://github.com/sdr-enthusiasts/docker-acarshub>.
+
+// acarshub is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// acarshub is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with acarshub.  If not, see <http://www.gnu.org/licenses/>.
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  _resetNavActionSlotForTesting,
+  registerNavActionSlot,
+} from "../../utils/navActionSlot";
+import { useNavActionSlot } from "../useNavActionSlot";
+
+afterEach(() => {
+  _resetNavActionSlotForTesting();
+});
+
+describe("useNavActionSlot", () => {
+  it("returns null when no slot is registered", () => {
+    const { result } = renderHook(() => useNavActionSlot());
+    expect(result.current).toBeNull();
+  });
+
+  it("returns a slot that was registered before the hook mounted", () => {
+    // The cold-load ordering: Navigation commits (and registers) before the
+    // routed page mounts, so the very first snapshot must already see it.
+    const el = document.createElement("div");
+    registerNavActionSlot(el);
+
+    const { result } = renderHook(() => useNavActionSlot());
+
+    expect(result.current).toBe(el);
+  });
+
+  it("re-renders with the slot when it is registered after mount", () => {
+    const { result } = renderHook(() => useNavActionSlot());
+    expect(result.current).toBeNull();
+
+    const el = document.createElement("div");
+    act(() => registerNavActionSlot(el));
+
+    expect(result.current).toBe(el);
+  });
+
+  it("returns null again when the slot is deregistered", () => {
+    // Happens on the mobile -> desktop transition. Consumers rely on this to
+    // stop portalling into a node that is no longer in the document.
+    const el = document.createElement("div");
+    registerNavActionSlot(el);
+    const { result } = renderHook(() => useNavActionSlot());
+    expect(result.current).toBe(el);
+
+    act(() => registerNavActionSlot(null));
+
+    expect(result.current).toBeNull();
+  });
+
+  it("tracks a slot element being swapped for a different one", () => {
+    const first = document.createElement("div");
+    const second = document.createElement("div");
+    registerNavActionSlot(first);
+
+    const { result } = renderHook(() => useNavActionSlot());
+    expect(result.current).toBe(first);
+
+    act(() => registerNavActionSlot(second));
+
+    expect(result.current).toBe(second);
+  });
+
+  it("unsubscribes on unmount so later registrations do not update it", () => {
+    const { result, unmount } = renderHook(() => useNavActionSlot());
+    unmount();
+
+    // Must not throw (a live subscription would try to set state on an
+    // unmounted component) and must not mutate the last-read value.
+    act(() => registerNavActionSlot(document.createElement("div")));
+
+    expect(result.current).toBeNull();
+  });
+});

--- a/acarshub-react/src/hooks/useAlertActionPlacement.ts
+++ b/acarshub-react/src/hooks/useAlertActionPlacement.ts
@@ -1,0 +1,85 @@
+// Copyright (C) 2022-2026 Frederick Clausen II
+// This file is part of acarshub <https://github.com/sdr-enthusiasts/docker-acarshub>.
+
+// acarshub is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// acarshub is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with acarshub.  If not, see <http://www.gnu.org/licenses/>.
+
+import {
+  MOBILE_NAV_QUERY,
+  PAGE_HEADER_HIDDEN_QUERY,
+} from "../utils/breakpoints";
+import { useMediaQuery } from "./useMediaQuery";
+
+/**
+ * Where the Alerts page anchors its primary action ("Mark All Read").
+ *
+ * The action must remain reachable at every viewport, but its natural home —
+ * `.page__header` — is hidden on short viewports. Rather than encode that as a
+ * pair of booleans at the call site (which would admit the meaningless
+ * "header hidden AND rendering into the header" combination), the resolved
+ * position is a single named state.
+ */
+export type AlertActionPlacement =
+  /**
+   * Inside `.page__header`, alongside the title and stat line.
+   * The preferred home: the action sits with the counts it acts upon.
+   */
+  | "page-header"
+  /**
+   * Inside the Live/Historical control row, anchored to its right edge.
+   * Used when the header is hidden but the viewport is still wide enough that
+   * a third item on the mode row does not crowd the two mode buttons.
+   */
+  | "controls-bar"
+  /**
+   * Portalled into the mobile nav bar, right of the msg/min widget.
+   * Used when the header is hidden AND the viewport is narrow: at phone
+   * widths the mode buttons already span the full row, so the nav bar is the
+   * only remaining always-visible position.
+   */
+  | "nav-slot";
+
+/**
+ * useAlertActionPlacement
+ *
+ * Resolves the placement of the Alerts page's "Mark All Read" action from the
+ * current viewport.
+ *
+ * The rule, in priority order:
+ *
+ * | Condition                          | Placement      |
+ * | ---------------------------------- | -------------- |
+ * | header visible (height > 800px)    | `page-header`  |
+ * | header hidden, width >= 768px      | `controls-bar` |
+ * | header hidden, width <= 767px      | `nav-slot`     |
+ *
+ * WHY height is checked before width:
+ * the header is suppressed by a height query alone, so whenever it is on
+ * screen it is the correct home regardless of how narrow the viewport is —
+ * relocating the action out of a *visible* header would leave a conspicuous
+ * gap next to the stats it belongs with. Width only becomes relevant once the
+ * header is gone and an alternative must be chosen.
+ *
+ * WHY the thresholds come from `utils/breakpoints`:
+ * both queries mirror CSS that governs whether the corresponding container is
+ * even on screen. A locally-written threshold that drifted from the SCSS would
+ * place the action into a hidden container — a failure that renders the
+ * action invisible while every unit test still passes.
+ */
+export function useAlertActionPlacement(): AlertActionPlacement {
+  const pageHeaderHidden = useMediaQuery(PAGE_HEADER_HIDDEN_QUERY);
+  const mobileNav = useMediaQuery(MOBILE_NAV_QUERY);
+
+  if (!pageHeaderHidden) return "page-header";
+  return mobileNav ? "nav-slot" : "controls-bar";
+}

--- a/acarshub-react/src/hooks/useNavActionSlot.ts
+++ b/acarshub-react/src/hooks/useNavActionSlot.ts
@@ -1,0 +1,80 @@
+// Copyright (C) 2022-2026 Frederick Clausen II
+// This file is part of acarshub <https://github.com/sdr-enthusiasts/docker-acarshub>.
+
+// acarshub is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// acarshub is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with acarshub.  If not, see <http://www.gnu.org/licenses/>.
+
+import { useEffect, useState, useSyncExternalStore } from "react";
+import {
+  getNavActionSlot,
+  subscribeToNavActionSlot,
+} from "../utils/navActionSlot";
+
+/**
+ * useNavActionSlot
+ *
+ * Returns the mobile nav bar's action slot element, or null when no slot is
+ * mounted (desktop nav, or before the nav's first commit).
+ *
+ * Pass the result to `createPortal` to project an action into the nav bar:
+ *
+ * ```tsx
+ * const slot = useNavActionSlot();
+ * return slot ? createPortal(<button …/>, slot) : null;
+ * ```
+ *
+ * WHY useSyncExternalStore rather than useState + useEffect:
+ * the slot appears and disappears as a *layout* consequence of a viewport
+ * change — the same resize that flips `Navigation` between its mobile and
+ * desktop trees. useSyncExternalStore subscribes during render and re-reads
+ * the store in the commit phase, so a page portalling into the slot cannot
+ * observe a tearing state where the nav has already swapped layouts but the
+ * page still holds the old (now-detached) element. An effect-based
+ * subscription would settle one commit later and could portal into a node
+ * that is no longer in the document.
+ */
+export function useNavActionSlot(): HTMLElement | null {
+  // getNavActionSlot is a stable module-level getter returning the same
+  // element identity between changes, satisfying useSyncExternalStore's
+  // requirement that getSnapshot be referentially stable across calls.
+  const slot = useSyncExternalStore(
+    subscribeToNavActionSlot,
+    getNavActionSlot,
+    // Server snapshot: no DOM, therefore no slot.
+    () => null,
+  );
+
+  // -------------------------------------------------------------------------
+  // Mount-order guard.
+  //
+  // `Navigation` and the routed page are siblings, and on a cold load with a
+  // deep link straight to a page that uses the slot, React may commit the page
+  // before the nav has attached its slot ref. The page's initial snapshot is
+  // then null and — because no *store* change follows, the slot having been
+  // registered before this component subscribed — no re-render is scheduled to
+  // correct it.
+  //
+  // Forcing one post-mount re-read closes that window. It runs once per mount
+  // and re-reads a module-level variable, so the cost is negligible; the
+  // setState is skipped entirely when the snapshot was already correct, which
+  // is the common case.
+  // -------------------------------------------------------------------------
+  const [, forceReread] = useState(0);
+  useEffect(() => {
+    if (getNavActionSlot() !== slot) {
+      forceReread((n) => n + 1);
+    }
+  }, [slot]);
+
+  return slot;
+}

--- a/acarshub-react/src/pages/AlertsPage.tsx
+++ b/acarshub-react/src/pages/AlertsPage.tsx
@@ -17,12 +17,18 @@
 import { useVirtualizer } from "@tanstack/react-virtual";
 import type React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { MessageCard } from "../components/MessageCard";
 import { MessageGroup } from "../components/MessageGroup";
+import {
+  type AlertActionPlacement,
+  useAlertActionPlacement,
+} from "../hooks/useAlertActionPlacement";
 import { useAlertsHistoricalSearch } from "../hooks/useAlertsHistoricalSearch";
 import { useAlertsListHeight } from "../hooks/useAlertsListHeight";
 import { useAlertsScrollAnchor } from "../hooks/useAlertsScrollAnchor";
 import { useAlertsScrollReset } from "../hooks/useAlertsScrollReset";
+import { useNavActionSlot } from "../hooks/useNavActionSlot";
 import { useRegisterScrollContainer } from "../hooks/useRegisterScrollContainer";
 import { socketService } from "../services/socket";
 import { useAppStore } from "../store/useAppStore";
@@ -50,6 +56,45 @@ const ESTIMATED_ITEM_HEIGHT = 300;
  * this zone, so live prepends flow in naturally without anchoring.
  */
 const LIST_PADDING_START = 16;
+
+/**
+ * The "Mark All Read" action.
+ *
+ * Extracted so that all three placements (page header, controls bar, nav slot)
+ * render the identical control rather than three near-copies that drift apart.
+ * The modifier class carries only positional/sizing differences; behaviour,
+ * label, and accessible name are placement-invariant, which is what lets the
+ * E2E suite assert on one role+name across every viewport.
+ */
+const MarkAllReadButton = ({
+  placement,
+  onClick,
+  unreadCount,
+}: {
+  placement: AlertActionPlacement;
+  onClick: () => void;
+  unreadCount: number;
+}) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className={`alerts-page__mark-read-button alerts-page__mark-read-button--${placement}`}
+    // The visible label is a fixed string, so the count — the one piece of
+    // information that tells the user what the action will actually affect —
+    // is otherwise announced nowhere.
+    //
+    // The accessible name MUST start with the visible text "Mark All Read":
+    // WCAG 2.5.3 (Label in Name) requires the accessible name to contain the
+    // visible label, so that speech-input users can activate the control by
+    // saying what they see. A name like "Mark all 5 unread alerts as read"
+    // would read naturally but fail that criterion.
+    aria-label={`Mark All Read (${unreadCount} unread)`}
+    title="Mark all alerts as read"
+    data-placement={placement}
+  >
+    Mark All Read
+  </button>
+);
 
 /**
  * AlertsPage Component
@@ -112,6 +157,11 @@ export const AlertsPage = () => {
   const activeTabIndices = useRef<Map<string, number>>(new Map());
 
   const listHeight = useAlertsListHeight(scrollContainerRef);
+
+  // Where "Mark All Read" is anchored at the current viewport. See
+  // hooks/useAlertActionPlacement.ts for the resolution rule.
+  const actionPlacement = useAlertActionPlacement();
+  const navActionSlot = useNavActionSlot();
 
   // Count total alert messages, unread alerts, and unique aircraft
   const stats = useMemo(() => {
@@ -304,22 +354,48 @@ export const AlertsPage = () => {
   const liveHasGroups = alertGroupsArray.length > 0;
   const histHasResults = historicalResults.length > 0;
 
+  /**
+   * Whether the "Mark All Read" action applies at all right now.
+   *
+   * Historical mode has no read/unread concept (results come straight from
+   * the DB), and with nothing unread the action would be a no-op — so it is
+   * omitted rather than shown disabled. This single predicate gates all three
+   * placements, which is what guarantees the button can never appear in two
+   * positions at once.
+   */
+  const showMarkAllRead = viewMode === "live" && stats.unreadAlerts > 0;
+
+  const markAllReadButton = showMarkAllRead ? (
+    <MarkAllReadButton
+      placement={actionPlacement}
+      onClick={handleMarkAllRead}
+      unreadCount={stats.unreadAlerts}
+    />
+  ) : null;
+
   return (
     <div className="page alerts-page">
+      {/*
+        Nav-slot placement.
+        Portalled into the mobile nav bar because at this viewport the header
+        is hidden and the mode row is already full-width. Rendered from here
+        (rather than from Navigation) so the action's handler and enabled
+        condition stay owned by the page that defines them.
+
+        The navActionSlot null-check is load-bearing, not defensive: on the
+        very first commit after a cold load the nav may not have attached its
+        slot yet, and createPortal throws on a null container.
+      */}
+      {actionPlacement === "nav-slot" &&
+        navActionSlot !== null &&
+        markAllReadButton !== null &&
+        createPortal(markAllReadButton, navActionSlot)}
+
       {/* Page Header */}
       <div className="page__header">
         <h1 className="page__title">Alerts</h1>
 
-        {viewMode === "live" && stats.unreadAlerts > 0 && (
-          <button
-            type="button"
-            onClick={handleMarkAllRead}
-            className="alerts-page__mark-read-button"
-            title="Mark all alerts as read"
-          >
-            Mark All Read
-          </button>
-        )}
+        {actionPlacement === "page-header" && markAllReadButton}
 
         <div className="page__stats">
           {viewMode === "live" ? (
@@ -362,23 +438,33 @@ export const AlertsPage = () => {
       <div className="page__content alerts-page__content">
         {/* Controls bar: mode toggle + optional term selector + pagination */}
         <div className="alerts-page__controls-bar">
-          {/* Mode Toggle */}
-          <div className="alerts-page__mode-toggle">
-            <button
-              type="button"
-              onClick={() => handleModeChange("live")}
-              className={`alerts-page__mode-button ${viewMode === "live" ? "alerts-page__mode-button--active" : ""}`}
-            >
-              Live
-            </button>
-            <button
-              type="button"
-              onClick={() => handleModeChange("historical")}
-              className={`alerts-page__mode-button ${viewMode === "historical" ? "alerts-page__mode-button--active" : ""}`}
-              disabled={noTermsConfigured}
-            >
-              Historical
-            </button>
+          {/*
+            Mode row: the Live/Historical toggle, plus — when the header is
+            hidden at tablet width and up — the Mark All Read action anchored
+            to the far right. The wrapper exists solely to give the action a
+            right-hand anchor on the same line as the toggle; the toggle keeps
+            its own element so its internal flex sizing is unaffected.
+          */}
+          <div className="alerts-page__mode-row">
+            <div className="alerts-page__mode-toggle">
+              <button
+                type="button"
+                onClick={() => handleModeChange("live")}
+                className={`alerts-page__mode-button ${viewMode === "live" ? "alerts-page__mode-button--active" : ""}`}
+              >
+                Live
+              </button>
+              <button
+                type="button"
+                onClick={() => handleModeChange("historical")}
+                className={`alerts-page__mode-button ${viewMode === "historical" ? "alerts-page__mode-button--active" : ""}`}
+                disabled={noTermsConfigured}
+              >
+                Historical
+              </button>
+            </div>
+
+            {actionPlacement === "controls-bar" && markAllReadButton}
           </div>
 
           {/* Historical term selector */}

--- a/acarshub-react/src/pages/__tests__/AlertsPage.test.tsx
+++ b/acarshub-react/src/pages/__tests__/AlertsPage.test.tsx
@@ -17,8 +17,13 @@
 import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AlertActionPlacement } from "../../hooks/useAlertActionPlacement";
 import { useAppStore } from "../../store/useAppStore";
 import type { AcarsMsg, MessageGroup } from "../../types";
+import {
+  _resetNavActionSlotForTesting,
+  registerNavActionSlot,
+} from "../../utils/navActionSlot";
 import { AlertsPage } from "../AlertsPage";
 
 // ---------------------------------------------------------------------------
@@ -147,6 +152,29 @@ vi.mock("../../utils/decoderUtils", () => ({
 }));
 
 // ---------------------------------------------------------------------------
+// useAlertActionPlacement mock
+//
+// The placement rule is a pure function of two media queries and is tested
+// exhaustively (including boundary pixels) in
+// hooks/__tests__/useAlertActionPlacement.test.ts. Here we only care which DOM
+// position each placement selects, so the hook is stubbed rather than driven
+// through a jsdom matchMedia harness — jsdom reports no layout, so a
+// viewport-based approach would be simulating the very thing under test.
+//
+// Defaults to "page-header" so every pre-existing test in this file keeps the
+// behaviour it was written against.
+// ---------------------------------------------------------------------------
+const placement = vi.hoisted(() => ({ current: "page-header" as string }));
+
+const setPlacement = (next: AlertActionPlacement): void => {
+  placement.current = next;
+};
+
+vi.mock("../../hooks/useAlertActionPlacement", () => ({
+  useAlertActionPlacement: () => placement.current,
+}));
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -221,6 +249,10 @@ function emitAlertsByTerm(
 
 describe("AlertsPage", () => {
   beforeEach(() => {
+    // Restore the default placement so a test that changed it cannot leak
+    // into the next one.
+    setPlacement("page-header");
+
     alertsByTermHandler = null;
     mockSocket.on.mockClear();
     mockSocket.off.mockClear();
@@ -741,6 +773,206 @@ describe("AlertsPage", () => {
 
       // 3 unique aircraft — may appear in multiple stat elements
       expect(screen.getAllByText("3").length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Mark All Read placement
+  //
+  // The action has three possible homes depending on viewport (see
+  // hooks/useAlertActionPlacement.ts). These tests pin the *wiring*: that the
+  // resolved placement selects exactly one DOM position, that the nav-slot
+  // case really portals out of the page, and that the action is never
+  // duplicated or orphaned. The placement *rule* itself is covered by
+  // hooks/__tests__/useAlertActionPlacement.test.ts.
+  // -------------------------------------------------------------------------
+
+  describe("mark all read placement", () => {
+    const withUnreadAlerts = (): void => {
+      useAppStore.setState({
+        alertMessageGroups: new Map([makeAlertGroup("UAL123", 2)]),
+        alertTerms: { terms: ["EMERGENCY"], ignore: [] },
+        readMessageUids: new Set(),
+      });
+    };
+
+    const markAllRead = () =>
+      screen.getByRole("button", { name: /mark all read/i });
+
+    afterEach(() => {
+      _resetNavActionSlotForTesting();
+    });
+
+    it("renders inside .page__header when the header is visible", () => {
+      setPlacement("page-header");
+      withUnreadAlerts();
+
+      render(<AlertsPage />);
+
+      const button = markAllRead();
+      expect(button.closest(".page__header")).not.toBeNull();
+      expect(button).toHaveAttribute("data-placement", "page-header");
+    });
+
+    it("renders inside the mode row when the header is hidden at >= 768px", () => {
+      setPlacement("controls-bar");
+      withUnreadAlerts();
+
+      render(<AlertsPage />);
+
+      const button = markAllRead();
+      // Must be on the same row as the Live/Historical toggle, not merely
+      // somewhere in the controls bar.
+      expect(button.closest(".alerts-page__mode-row")).not.toBeNull();
+      expect(button.closest(".page__header")).toBeNull();
+      expect(button).toHaveAttribute("data-placement", "controls-bar");
+    });
+
+    it("portals into the nav slot when the header is hidden at <= 767px", () => {
+      setPlacement("nav-slot");
+      withUnreadAlerts();
+
+      const slot = document.createElement("div");
+      slot.className = "mobile_nav_action_slot";
+      document.body.appendChild(slot);
+      registerNavActionSlot(slot);
+
+      const { container } = render(<AlertsPage />);
+
+      const button = markAllRead();
+      expect(slot.contains(button)).toBe(true);
+      // The whole point of the portal: the button is NOT inside the page's
+      // own subtree at this viewport.
+      expect(container.contains(button)).toBe(false);
+      expect(button).toHaveAttribute("data-placement", "nav-slot");
+
+      slot.remove();
+    });
+
+    it("omits the action entirely when nav-slot is resolved but no slot is mounted", () => {
+      // Guards the createPortal(null) crash: on a cold load the page can
+      // commit before Navigation has attached its slot.
+      setPlacement("nav-slot");
+      withUnreadAlerts();
+
+      expect(() => render(<AlertsPage />)).not.toThrow();
+
+      expect(
+        screen.queryByRole("button", { name: /mark all read/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("renders the action exactly once at every placement", () => {
+      // A regression here (e.g. rendering all three and hiding two with CSS)
+      // would put duplicate identically-named buttons in the a11y tree.
+      for (const placement of [
+        "page-header",
+        "controls-bar",
+        "nav-slot",
+      ] as const) {
+        setPlacement(placement);
+        withUnreadAlerts();
+
+        const slot = document.createElement("div");
+        document.body.appendChild(slot);
+        registerNavActionSlot(slot);
+
+        const { unmount } = render(<AlertsPage />);
+
+        expect(
+          screen.getAllByRole("button", { name: /mark all read/i }),
+        ).toHaveLength(1);
+
+        unmount();
+        slot.remove();
+        _resetNavActionSlotForTesting();
+      }
+    });
+
+    it("keeps the action clickable when portalled into the nav slot", async () => {
+      // Portalled content keeps React's synthetic event path, but only if the
+      // portal is rendered from within the page's tree — verify the handler
+      // actually fires rather than assuming.
+      setPlacement("nav-slot");
+      withUnreadAlerts();
+
+      const slot = document.createElement("div");
+      document.body.appendChild(slot);
+      registerNavActionSlot(slot);
+
+      const markAllSpy = vi.spyOn(
+        useAppStore.getState(),
+        "markAllAlertsAsRead",
+      );
+
+      const user = userEvent.setup();
+      render(<AlertsPage />);
+
+      await user.click(markAllRead());
+
+      expect(markAllSpy).toHaveBeenCalledOnce();
+
+      slot.remove();
+    });
+
+    it("is absent in historical mode regardless of placement", async () => {
+      // Historical results have no read/unread state, so the action would be
+      // a no-op. Checked at the nav-slot placement because that is the one
+      // that leaks outside the page subtree and would otherwise linger in the
+      // nav bar after a mode switch.
+      setPlacement("nav-slot");
+      withUnreadAlerts();
+
+      const slot = document.createElement("div");
+      document.body.appendChild(slot);
+      registerNavActionSlot(slot);
+
+      const user = userEvent.setup();
+      render(<AlertsPage />);
+
+      expect(markAllRead()).toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: /historical/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.queryByRole("button", { name: /mark all read/i }),
+        ).not.toBeInTheDocument();
+      });
+      expect(slot).toBeEmptyDOMElement();
+
+      slot.remove();
+    });
+
+    it("removes the portalled action from the nav slot on unmount", () => {
+      // Navigating away from Alerts must not leave a stale button in the nav
+      // bar acting on a page that is no longer mounted.
+      setPlacement("nav-slot");
+      withUnreadAlerts();
+
+      const slot = document.createElement("div");
+      document.body.appendChild(slot);
+      registerNavActionSlot(slot);
+
+      const { unmount } = render(<AlertsPage />);
+      expect(slot).not.toBeEmptyDOMElement();
+
+      unmount();
+
+      expect(slot).toBeEmptyDOMElement();
+
+      slot.remove();
+    });
+
+    it("exposes an accessible name containing the visible label and the count", () => {
+      // WCAG 2.5.3 Label in Name: speech-input users must be able to say what
+      // they see, so the accessible name has to start with "Mark All Read".
+      setPlacement("page-header");
+      withUnreadAlerts();
+
+      render(<AlertsPage />);
+
+      expect(markAllRead()).toHaveAccessibleName("Mark All Read (2 unread)");
     });
   });
 });

--- a/acarshub-react/src/styles/__tests__/alerts-action-styles.test.ts
+++ b/acarshub-react/src/styles/__tests__/alerts-action-styles.test.ts
@@ -1,0 +1,79 @@
+/* Copyright (C) 2022-2026 Frederick Clausen II
+ * This file is part of acarshub <https://github.com/sdr-enthusiasts/docker-acarshub>.
+ *
+ * acarshub is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * acarshub is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with acarshub.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/// <reference types="node" />
+
+/**
+ * Source-level guards for the Alerts "Mark All Read" action's styles.
+ *
+ * The action's *rendered* behaviour — which placement is chosen, whether it
+ * is visible, whether it matches the mode buttons' height — is covered by
+ * e2e/alerts-action-placement.spec.ts, which is where anything requiring a
+ * real layout engine belongs.
+ *
+ * What is left here are properties of the stylesheet itself that a browser
+ * cannot report on, because the failure mode is a declaration silently doing
+ * nothing rather than doing something wrong.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const stylesDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+/** Reads a stylesheet with `//` comments stripped — see the note in
+ * page-header-typography.test.ts for why. */
+function read(relative: string): string {
+  return readFileSync(resolve(stylesDir, relative), "utf-8").replace(
+    /^\s*\/\/.*$/gm,
+    "",
+  );
+}
+
+const alerts = read("pages/_alerts.scss");
+
+describe("Mark All Read button styles", () => {
+  it("does not reference the nonexistent --font-size-base token", () => {
+    // The rule previously declared `font-size: var(--font-size-base)`. That
+    // token is not defined anywhere (the theme layer exposes --font-size-md),
+    // so the declaration resolved to nothing and the button silently
+    // inherited its size instead of taking the intended one.
+    //
+    // This is exactly the class of bug a browser cannot surface: no error, no
+    // warning, and a rendered result that looks plausible.
+    expect(alerts).not.toMatch(/var\(--font-size-base\)/);
+  });
+
+  it("sizes the controls-bar placement by stretching, not by restating metrics", () => {
+    // The action must be exactly as tall as the mode buttons it sits beside.
+    // That is achieved with align-self:stretch so the row height stays the
+    // single source of truth.
+    //
+    // Re-deriving the height by copying the mode button's padding/font into
+    // this rule would look equivalent and pass the E2E height check today,
+    // while silently decoupling the two the next time either is adjusted.
+    // Pin the mechanism, not just the outcome.
+    const controlsBar = alerts.match(
+      /&--controls-bar\s*\{([\s\S]*?)\n {4}\}/,
+    )?.[1];
+
+    expect(controlsBar, "&--controls-bar rule not found").toBeDefined();
+    expect(controlsBar).toMatch(/align-self:\s*stretch;/);
+  });
+});

--- a/acarshub-react/src/styles/__tests__/page-header-typography.test.ts
+++ b/acarshub-react/src/styles/__tests__/page-header-typography.test.ts
@@ -1,0 +1,124 @@
+/* Copyright (C) 2022-2026 Frederick Clausen II
+ * This file is part of acarshub <https://github.com/sdr-enthusiasts/docker-acarshub>.
+ *
+ * acarshub is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * acarshub is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with acarshub.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/// <reference types="node" />
+
+/**
+ * `.page__header` typography regression tests.
+ *
+ * The header is a single dense row holding a page title, a stat line, and
+ * (on Alerts) the Mark All Read action. It previously styled the title on a
+ * document-heading scale — 1.5rem rising to 1.875rem at >=768px — against
+ * 1rem stats and a 0.875rem button, making the title roughly double the
+ * height of everything beside it.
+ *
+ * These tests pin the corrected relationship. They are source-level rather
+ * than rendered assertions because the property under test is the *declared
+ * scale relationship* between sibling rules, which is far more legible in the
+ * SCSS than reconstructed from computed styles in a browser.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const stylesDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+/**
+ * Reads a stylesheet with `//` comments stripped.
+ *
+ * WHY: these tests assert on the absence of certain declarations, and the
+ * SCSS documents the very patterns being banned ("this was
+ * var(--font-size-base), which is wrong..."). Matching raw source would flag
+ * the explanation as if it were the offence.
+ */
+function read(relative: string): string {
+  return readFileSync(resolve(stylesDir, relative), "utf-8").replace(
+    /^\s*\/\/.*$/gm,
+    "",
+  );
+}
+
+/** Extracts the body of a top-level rule (non-nested) by selector. */
+function ruleBody(scss: string, selector: string): string {
+  const match = scss.match(
+    new RegExp(`\\n\\${selector}\\s*\\{([\\s\\S]*?)\\n\\}`),
+  );
+  if (!match) throw new Error(`Rule not found: ${selector}`);
+  return match[1];
+}
+
+const common = read("pages/_common.scss");
+
+describe(".page__title sizing", () => {
+  const title = ruleBody(common, ".page__title");
+
+  it("is 1rem so it matches the other content of the header row", () => {
+    expect(title).toMatch(/font-size:\s*\$font-size-base;/);
+  });
+
+  it("does not use a heading-scale size", () => {
+    // The exact regression: 2xl (1.5rem) / 3xl (1.875rem).
+    expect(title).not.toMatch(/\$font-size-(?:2xl|3xl|4xl)/);
+  });
+
+  it("has no breakpoint step-up", () => {
+    // The old rule grew the title at >=768px, which widened the mismatch on
+    // exactly the screens with the most room. Size is now flat.
+    expect(title).not.toMatch(/@include\s+breakpoint\(/);
+  });
+
+  it("keeps semibold weight to stay distinguishable from the stats", () => {
+    // Size no longer separates the title from its neighbours, so weight and
+    // colour are now doing that work alone.
+    expect(title).toMatch(/font-weight:\s*\$font-weight-semibold;/);
+    expect(title).toMatch(/color:\s*var\(--color-text\);/);
+  });
+});
+
+describe(".page__subtitle sizing", () => {
+  const subtitle = ruleBody(common, ".page__subtitle");
+
+  it("stays one step below the title at every width", () => {
+    expect(subtitle).toMatch(/font-size:\s*\$font-size-sm;/);
+  });
+
+  it("does not step up to the title's size at >=768px", () => {
+    // It used to become $font-size-base at md, which now equals the title's
+    // size and would flatten the title/subtitle relationship on About.
+    expect(subtitle).not.toMatch(/@include\s+breakpoint\(/);
+  });
+});
+
+describe("font-size token hygiene", () => {
+  it("--font-size-base is not a defined CSS custom property", () => {
+    // Pins the premise behind the rule below: the theme layer exposes
+    // --font-size-md, and there is deliberately no --font-size-base. A
+    // `var(--font-size-base)` therefore resolves to nothing and silently
+    // falls back to inherited sizing rather than erroring.
+    //
+    // Should someone later define the token, this test fails and the
+    // "never reference it" rules elsewhere can be retired rather than
+    // lingering as cargo cult.
+    expect(read("_themes.scss")).not.toMatch(/--font-size-base:/);
+  });
+
+  it("pages/_common.scss does not reference the nonexistent token", () => {
+    expect(common).not.toMatch(/var\(--font-size-base\)/);
+  });
+});

--- a/acarshub-react/src/styles/components/_navigation.scss
+++ b/acarshub-react/src/styles/components/_navigation.scss
@@ -403,6 +403,29 @@
   display: flex;
   align-items: center;
   gap: $spacing-md;
+  // The left group holds the menu toggle and the optional Filters button,
+  // both of which have fixed short labels. Letting it shrink first keeps the
+  // right group (msg/min + page action) intact on narrow screens.
+  min-width: 0;
+}
+
+// Right group of the mobile nav: msg/min widget followed by the page action
+// slot. Grouped so both stay pinned to the right edge under the container's
+// space-between, instead of the action being pushed into the middle.
+.mobile_nav_right {
+  display: flex;
+  align-items: center;
+  gap: $spacing-sm;
+  flex-shrink: 0;
+}
+
+// Page action slot — populated by the active page via a portal (see
+// utils/navActionSlot.ts). Collapses to nothing when unoccupied: `display:
+// flex` on an empty element with no padding or gap contributes zero width, so
+// an unused slot cannot shift the msg/min widget off the right edge.
+.mobile_nav_action_slot {
+  display: flex;
+  align-items: center;
 }
 
 .mobile_nav_button {

--- a/acarshub-react/src/styles/pages/_about.scss
+++ b/acarshub-react/src/styles/pages/_about.scss
@@ -18,6 +18,19 @@
 @use "../mixins" as *;
 
 .about-page {
+  // Opt in to a gap between the nav bar and the page.
+  //
+  // `.page` defaults to flush-against-the-nav because the tool surfaces
+  // (Live Messages, Alerts, Search, Stats, Map) all want every available
+  // vertical pixel for content. About is a document, not a tool: it is read
+  // rather than monitored, and the detachment reinforces that. This is the
+  // deliberate exception, declared here rather than assumed globally.
+  margin-top: $spacing-sm; // mobile-first
+
+  @include media-md {
+    margin-top: $spacing-lg;
+  }
+
   // Mobile-first: single column layout
   .page__content {
     display: flex;

--- a/acarshub-react/src/styles/pages/_alerts.scss
+++ b/acarshub-react/src/styles/pages/_alerts.scss
@@ -73,15 +73,34 @@
     padding-bottom: var(--spacing-lg);
   }
 
+  // Mode row: wraps the Live/Historical toggle and, when the page header is
+  // hidden at >= 768px, the Mark All Read action anchored to the far right.
+  //
+  // The toggle keeps `flex: 1` so it behaves exactly as it did before this
+  // wrapper existed when no action is present; the action is `flex-shrink: 0`
+  // so a long mode label can never squeeze it out of view.
+  &__mode-row {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+    // Vertical breathing room lives here rather than on __mode-toggle so that
+    // the row's content height equals the mode buttons' height exactly. That
+    // is what lets the Mark All Read action `align-self: stretch` to the same
+    // height as the mode buttons instead of to the buttons-plus-padding box.
+    padding: var(--spacing-xs) 0;
+  }
+
   // Mode toggle (Live/Historical)
   &__mode-toggle {
     display: flex;
     gap: var(--spacing-xs);
-    padding: var(--spacing-xs) 0;
     justify-content: center; // mobile-first
+    flex: 1;
+    min-width: 0;
 
     @include breakpoint(md) {
       justify-content: unset;
+      flex: unset;
     }
   }
 
@@ -358,14 +377,20 @@
 
   // Mark All Read button
   //
-  // Lives as a direct child of .page__header so it can be repositioned
-  // independently of .page__stats on mobile.
+  // The action has three possible homes, selected in JS by
+  // hooks/useAlertActionPlacement.ts and expressed here as --page-header /
+  // --controls-bar / --nav-slot modifiers. Exactly one is ever rendered.
   //
-  // Layout strategy (flex order within .page__header):
-  //   Desktop — title(0) › stats(2, margin-left:auto) › button(3)
-  //             Replicates the original "button at the end of the stats row" look.
-  //   Mobile  — title(0) › button(1) › stats(2, width:100% wraps to own row)
-  //             Puts the button on the title line, right-aligned via space-between.
+  // WHY placement is a JS decision with CSS modifiers, rather than three
+  // always-rendered copies hidden by media queries: the nav-slot position is
+  // in a different part of the DOM tree (a portal into the nav bar), so CSS
+  // cannot move the element there. Rendering three copies would also put three
+  // identically-named buttons in the accessibility tree, breaking
+  // getByRole("button", { name: /mark all read/i }) for both tests and screen
+  // readers.
+  //
+  // Shared appearance lives on the base class; each modifier adds only the
+  // positioning and density its container needs.
   &__mark-read-button {
     background: var(--color-green);
     color: var(--color-base);
@@ -374,24 +399,76 @@
     font-weight: 600;
     cursor: pointer;
     transition: all var(--transition-fast);
+    white-space: nowrap;
+    // Never let a flex parent shrink the action below its label — being
+    // clipped is indistinguishable from being missing.
+    flex-shrink: 0;
 
-    // Mobile-first: appear between title (order 0) and stats (order 2) so
-    // it sits on the same row as the title.
-    //
-    // SCSS-TOUCH: previously exempted from the 44px rule as a "secondary
-    // header action". Per remediation policy that exemption is removed --
-    // 44px floor by default. Desktop keeps compact padding/font for header
-    // density and appears after .page__stats instead.
-    order: 1;
+    // SCSS-TOUCH: 44px floor by default. Individual placements relax this
+    // only where the container is itself a compact desktop-density row.
     min-height: 44px;
     padding: var(--spacing-sm) var(--spacing-md);
-    font-size: var(--font-size-base);
+    // NOTE: this was `var(--font-size-base)`, which is not a token that
+    // exists -- _themes.scss defines --font-size-md, not --font-size-base --
+    // so the declaration silently resolved to nothing and the button
+    // inherited its size. Corrected to the real token while rewriting this
+    // rule.
+    font-size: var(--font-size-md);
 
-    @include breakpoint(md) {
-      order: 3;
+    // -- Placement: inside .page__header (viewport height > 800px) ----------
+    //
+    // Flex order within .page__header:
+    //   Mobile  — title(0) › button(1) › stats(2, width:100% wraps to own row)
+    //   Desktop — title(0) › stats(2, margin-left:auto) › button(3)
+    &--page-header {
+      order: 1;
+
+      @include breakpoint(md) {
+        order: 3;
+        min-height: unset;
+        padding: var(--spacing-xs) var(--spacing-sm);
+        font-size: var(--font-size-sm);
+      }
+    }
+
+    // -- Placement: mode row (header hidden, width >= 768px) ----------------
+    //
+    // margin-left:auto anchors it to the far right of the row, opposite the
+    // Live/Historical toggle.
+    //
+    // Height MUST match .alerts-page__mode-button exactly — the two sit side
+    // by side on one row, and a few pixels of difference reads as a
+    // misalignment rather than as deliberate hierarchy.
+    //
+    // This is done with align-self:stretch rather than by restating the mode
+    // button's padding/font/border metrics. Restating them would be a silent
+    // coupling: the next person to adjust the mode button's padding would
+    // have no indication that a second rule needs the same edit, and the row
+    // would quietly go crooked. Stretching makes the row's own height — which
+    // the mode button already defines, being the tallest item — the single
+    // source of truth.
+    &--controls-bar {
+      margin-left: auto;
+      align-self: stretch;
+      // The stretched height now governs; the 44px floor would only fight it
+      // if the mode button were ever shorter than 44px (it is not, but this
+      // keeps the two from disagreeing).
       min-height: unset;
+      padding: var(--spacing-xs) var(--spacing-md);
+      font-size: var(--font-size-sm);
+    }
+
+    // -- Placement: mobile nav bar (header hidden, width <= 767px) ----------
+    //
+    // Shares the nav bar with the msg/min widget on a phone-width line, so
+    // this is the one placement that must actively conserve horizontal space.
+    // The 44px touch floor is preserved on the vertical axis; horizontal
+    // padding is trimmed and the font stepped down to keep the nav on one
+    // line at 320px, where the widget is hidden anyway (it needs 375px).
+    &--nav-slot {
       padding: var(--spacing-xs) var(--spacing-sm);
       font-size: var(--font-size-sm);
+      line-height: 1;
     }
 
     &:hover {

--- a/acarshub-react/src/styles/pages/_alerts.scss
+++ b/acarshub-react/src/styles/pages/_alerts.scss
@@ -25,9 +25,9 @@
 }
 
 .alerts-page {
-  // Override parent .page margins/border-radius so the page occupies the full
-  // viewport area below the nav bar with no gaps or rounded corners.
-  margin-top: 0;
+  // Override parent .page bottom margin and border-radius so the page occupies
+  // the full viewport area below the nav bar with no gaps or rounded corners.
+  // (Top margin needs no override — `.page` is flush by default.)
   margin-bottom: 0;
   border-radius: 0;
   overflow: visible !important;

--- a/acarshub-react/src/styles/pages/_common.scss
+++ b/acarshub-react/src/styles/pages/_common.scss
@@ -24,9 +24,24 @@
  */
 
 .page {
-  // Mobile-first.
-  margin-top: $spacing-sm;
-  margin-bottom: $spacing-sm;
+  // Pages sit flush against the nav bar. There is NO top margin by default.
+  //
+  // WHY the default is 0: this used to be $spacing-sm / $spacing-lg, and every
+  // app-like page then had to override it back to 0 — Live Messages and Alerts
+  // with an explicit `margin-top: 0`, Stats via `margin: 0 auto auto auto`,
+  // Live Map via `margin: 0 !important`. Search was the one page that never
+  // got the override, so it alone rendered a 24px gap above its header, making
+  // its header area look ~45% taller than every other page's. That is a
+  // default which the majority of consumers actively fight; the default was
+  // wrong, not Search.
+  //
+  // A page that genuinely wants to float below the nav (About, which is a
+  // document rather than a tool surface) opts in explicitly — see
+  // `.about-page` in pages/_about.scss.
+  //
+  // Bottom margin is unchanged: trailing space at the end of a scrolled page
+  // is wanted everywhere and was never the anomaly.
+  margin-bottom: $spacing-sm; // mobile-first
   border-radius: $radius-md;
   background-color: var(--color-card-body);
   overflow: clip;
@@ -35,7 +50,6 @@
   @include fade-in($transition-base);
 
   @include breakpoint(md) {
-    margin-top: $spacing-lg;
     margin-bottom: $spacing-lg;
     border-radius: $radius-xl;
   }

--- a/acarshub-react/src/styles/pages/_common.scss
+++ b/acarshub-react/src/styles/pages/_common.scss
@@ -73,24 +73,41 @@
 
 .page__title {
   margin: 0;
-  font-size: $font-size-2xl; // mobile-first
+  // Sized to match the other content of .page__header (the stat line at
+  // 1rem, the Mark All Read action at 0.875rem) rather than to a heading
+  // scale.
+  //
+  // WHY not $font-size-2xl/3xl as before: the header is a single dense row of
+  // page-level metadata, not a document title block. At 1.5rem/1.875rem the
+  // title was roughly double the height of everything beside it, which read
+  // as an oversized banner rather than a row. The page is already identified
+  // by the active nav link, so the title's job here is orientation, not
+  // hierarchy.
+  //
+  // Deliberately flat across breakpoints: the previous step-up to 1.875rem at
+  // >=768px made the mismatch worse on exactly the wide screens where the row
+  // has the most horizontal space and the least need for emphasis.
+  //
+  // Semantics are unaffected — this is still an <h1>, so the document outline
+  // and screen-reader heading navigation are unchanged. Weight (600) and the
+  // full-contrast --color-text still distinguish it from the subtext-coloured
+  // stats beside it.
+  font-size: $font-size-base;
   font-weight: $font-weight-semibold;
   color: var(--color-text);
-
-  @include breakpoint(md) {
-    font-size: $font-size-3xl;
-  }
 }
 
 .page__subtitle {
   margin: $spacing-sm 0 0;
-  font-size: $font-size-sm; // mobile-first
+  // Held at 0.875rem at every width. It previously stepped up to 1rem at
+  // >=768px, which was fine when the title above it was 1.875rem — but now
+  // that .page__title is 1rem flat, that step would render the subtitle at
+  // exactly the title's size and flatten the relationship between them.
+  // Staying one step down keeps the title dominant on the only page that
+  // uses a subtitle (About).
+  font-size: $font-size-sm;
   font-weight: $font-weight-normal;
   color: var(--color-subtext1);
-
-  @include breakpoint(md) {
-    font-size: $font-size-base;
-  }
 }
 
 .page__actions {

--- a/acarshub-react/src/styles/pages/_live-messages.scss
+++ b/acarshub-react/src/styles/pages/_live-messages.scss
@@ -38,9 +38,9 @@
   overflow: visible !important;
   display: flex;
   flex-direction: column;
-  // Remove .page margins and border-radius so the page occupies the full
-  // viewport area below the nav bar with no gaps or rounded edges.
-  margin-top: 0;
+  // Remove the .page bottom margin and border-radius so the page occupies the
+  // full viewport area below the nav bar with no gaps or rounded edges.
+  // (Top margin needs no override — `.page` is flush by default.)
   margin-bottom: 0;
   border-radius: 0;
   // Height is set via inline style by LiveMessagesPage using a ResizeObserver

--- a/acarshub-react/src/utils/__tests__/breakpoints.test.ts
+++ b/acarshub-react/src/utils/__tests__/breakpoints.test.ts
@@ -1,0 +1,93 @@
+// Copyright (C) 2022-2026 Frederick Clausen II
+// This file is part of acarshub <https://github.com/sdr-enthusiasts/docker-acarshub>.
+
+// acarshub is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// acarshub is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with acarshub.  If not, see <http://www.gnu.org/licenses/>.
+
+// ---------------------------------------------------------------------------
+// Guards the TS <-> SCSS breakpoint mirror.
+//
+// utils/breakpoints.ts duplicates two thresholds that are *defined* in SCSS.
+// Duplication is unavoidable (JS cannot read a media query out of a stylesheet
+// at runtime), so instead of trusting a comment, these tests parse the SCSS
+// sources and assert the numbers still agree.
+//
+// A drift here is otherwise invisible: the Alerts "Mark All Read" action would
+// be placed into a container that CSS has hidden, producing a button that is
+// in the DOM, passes every render test, and cannot be seen or clicked.
+// ---------------------------------------------------------------------------
+
+/// <reference types="node" />
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  MOBILE_NAV_MAX_WIDTH_PX,
+  MOBILE_NAV_QUERY,
+  PAGE_HEADER_HIDDEN_MAX_HEIGHT_PX,
+  PAGE_HEADER_HIDDEN_QUERY,
+} from "../breakpoints";
+
+// Resolve relative to this file rather than cwd, matching the convention in
+// styles/__tests__/ and keeping the test independent of where vitest is run
+// from.
+const stylesDir = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../styles",
+);
+
+const read = (relativePath: string): string =>
+  readFileSync(resolve(stylesDir, relativePath), "utf8");
+
+describe("breakpoints TS/SCSS mirror", () => {
+  it("PAGE_HEADER_HIDDEN_MAX_HEIGHT_PX matches the max-height that hides .page__header", () => {
+    const scss = read("pages/_common.scss");
+
+    // Find the `@media (max-height: Npx)` block that contains a
+    // `.page__header { display: none }` rule.
+    const match = scss.match(
+      /@media\s*\(max-height:\s*(\d+)px\)\s*\{\s*\.page__header\s*\{\s*display:\s*none;/,
+    );
+
+    expect(
+      match,
+      "could not find the `@media (max-height: …) { .page__header { display: none } }` " +
+        "rule in styles/pages/_common.scss. If the header is now hidden by a " +
+        "different mechanism, update utils/breakpoints.ts and this test together.",
+    ).not.toBeNull();
+
+    expect(Number(match?.[1])).toBe(PAGE_HEADER_HIDDEN_MAX_HEIGHT_PX);
+  });
+
+  it("MOBILE_NAV_MAX_WIDTH_PX is exactly one below the SCSS md breakpoint", () => {
+    const variables = read("_variables.scss");
+    const match = variables.match(/\$breakpoint-md:\s*(\d+)px/);
+
+    expect(
+      match,
+      "could not find `$breakpoint-md` in styles/_variables.scss",
+    ).not.toBeNull();
+
+    // The JS max-width query and the SCSS min-width mixin must partition the
+    // width axis with no overlapping pixel (both layouts active) and no gap
+    // (neither active).
+    expect(MOBILE_NAV_MAX_WIDTH_PX).toBe(Number(match?.[1]) - 1);
+  });
+
+  it("exposes the thresholds as well-formed media query strings", () => {
+    expect(PAGE_HEADER_HIDDEN_QUERY).toBe("(max-height: 800px)");
+    expect(MOBILE_NAV_QUERY).toBe("(max-width: 767px)");
+  });
+});

--- a/acarshub-react/src/utils/__tests__/navActionSlot.test.ts
+++ b/acarshub-react/src/utils/__tests__/navActionSlot.test.ts
@@ -1,0 +1,129 @@
+// Copyright (C) 2022-2026 Frederick Clausen II
+// This file is part of acarshub <https://github.com/sdr-enthusiasts/docker-acarshub>.
+
+// acarshub is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// acarshub is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with acarshub.  If not, see <http://www.gnu.org/licenses/>.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  _resetNavActionSlotForTesting,
+  getNavActionSlot,
+  registerNavActionSlot,
+  subscribeToNavActionSlot,
+} from "../navActionSlot";
+
+afterEach(() => {
+  _resetNavActionSlotForTesting();
+});
+
+describe("navActionSlot registry", () => {
+  it("returns null before any slot is registered", () => {
+    expect(getNavActionSlot()).toBeNull();
+  });
+
+  it("returns the registered element", () => {
+    const el = document.createElement("div");
+    registerNavActionSlot(el);
+    expect(getNavActionSlot()).toBe(el);
+  });
+
+  it("returns null again after deregistration", () => {
+    const el = document.createElement("div");
+    registerNavActionSlot(el);
+    registerNavActionSlot(null);
+    expect(getNavActionSlot()).toBeNull();
+  });
+
+  it("replaces the previous slot when a new one is registered", () => {
+    // Happens on a mobile -> desktop -> mobile transition, where the nav
+    // unmounts and remounts its slot as a brand new element.
+    const first = document.createElement("div");
+    const second = document.createElement("div");
+    registerNavActionSlot(first);
+    registerNavActionSlot(second);
+    expect(getNavActionSlot()).toBe(second);
+  });
+
+  it("notifies subscribers synchronously with the new slot", () => {
+    // Synchronous notification is what lets a page re-render in the same
+    // commit as the nav swapping layouts, so the action never disappears for
+    // a frame.
+    const cb = vi.fn();
+    subscribeToNavActionSlot(cb);
+
+    const el = document.createElement("div");
+    registerNavActionSlot(el);
+
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(cb).toHaveBeenCalledWith(el);
+  });
+
+  it("notifies subscribers with null on deregistration", () => {
+    const cb = vi.fn();
+    subscribeToNavActionSlot(cb);
+
+    registerNavActionSlot(document.createElement("div"));
+    registerNavActionSlot(null);
+
+    expect(cb).toHaveBeenLastCalledWith(null);
+  });
+
+  it("does not invoke the callback at subscription time", () => {
+    // Documented contract, mirroring subscribeToScrollContainer: callers read
+    // the initial value with getNavActionSlot() instead.
+    registerNavActionSlot(document.createElement("div"));
+
+    const cb = vi.fn();
+    subscribeToNavActionSlot(cb);
+
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("notifies every subscriber", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    subscribeToNavActionSlot(first);
+    subscribeToNavActionSlot(second);
+
+    const el = document.createElement("div");
+    registerNavActionSlot(el);
+
+    expect(first).toHaveBeenCalledWith(el);
+    expect(second).toHaveBeenCalledWith(el);
+  });
+
+  it("stops notifying after unsubscribe", () => {
+    // A leak here would keep unmounted pages re-rendering on every nav layout
+    // change for the lifetime of the tab.
+    const cb = vi.fn();
+    const unsubscribe = subscribeToNavActionSlot(cb);
+    unsubscribe();
+
+    registerNavActionSlot(document.createElement("div"));
+
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("unsubscribing one subscriber leaves the others attached", () => {
+    const kept = vi.fn();
+    const dropped = vi.fn();
+    subscribeToNavActionSlot(kept);
+    const unsubscribe = subscribeToNavActionSlot(dropped);
+    unsubscribe();
+
+    registerNavActionSlot(document.createElement("div"));
+
+    expect(kept).toHaveBeenCalledTimes(1);
+    expect(dropped).not.toHaveBeenCalled();
+  });
+});

--- a/acarshub-react/src/utils/breakpoints.ts
+++ b/acarshub-react/src/utils/breakpoints.ts
@@ -1,0 +1,81 @@
+// Copyright (C) 2022-2026 Frederick Clausen II
+// This file is part of acarshub <https://github.com/sdr-enthusiasts/docker-acarshub>.
+
+// acarshub is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// acarshub is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with acarshub.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Shared viewport breakpoints for the small number of places where JS layout
+ * decisions must agree *exactly* with a CSS media query.
+ *
+ * WHY this file exists:
+ * Most responsive behaviour in ACARS Hub is pure SCSS (`@include
+ * breakpoint(md)`) and needs no JS counterpart. A few cases genuinely cannot
+ * be expressed in CSS alone — notably relocating a control into a *different
+ * part of the DOM tree* (a React portal) rather than merely restyling it in
+ * place. Those cases require JS to evaluate the same threshold that the SCSS
+ * uses, and if the two ever disagree the UI breaks in ways that are invisible
+ * to both the type checker and to any single-viewport test: a control can end
+ * up rendered into a portal target that CSS has hidden, or duplicated in two
+ * visible places at once.
+ *
+ * The values below are therefore *mirrors* of SCSS declarations, and
+ * `utils/__tests__/breakpoints.test.ts` parses the SCSS at test time to prove
+ * the mirror is still accurate. Change one and the test tells you to change
+ * the other.
+ *
+ * NOTE: this is deliberately NOT a general re-export of the SCSS
+ * `$breakpoint-*` scale. Duplicating the whole scale into TS would invite JS
+ * media queries where a plain SCSS rule would do. Only add an entry here when
+ * a JS consumer provably needs it.
+ */
+
+/**
+ * Viewport height (px) at or below which `.page__header` is hidden.
+ *
+ * Mirrors: `@media (max-height: 800px) { .page__header { display: none } }`
+ * in `styles/pages/_common.scss`.
+ *
+ * The header carries each page's title, stat line, and (on Alerts) the
+ * "Mark All Read" action. It is suppressed on short viewports because the
+ * information it holds is largely redundant with the nav bar and the page
+ * body, and the vertical space is worth more to the message list.
+ */
+export const PAGE_HEADER_HIDDEN_MAX_HEIGHT_PX = 800;
+
+/**
+ * Viewport width (px) at or below which `Navigation` renders its mobile
+ * layout (`.mobile_nav_container`) instead of the desktop nav (`ul.primary`).
+ *
+ * This is one below the SCSS `$breakpoint-md` (768px) so that the JS
+ * `max-width` query and the SCSS `min-width` query partition the axis with no
+ * overlap and no gap.
+ */
+export const MOBILE_NAV_MAX_WIDTH_PX = 767;
+
+/**
+ * Matches when `.page__header` is hidden by CSS.
+ *
+ * Consumers that render into or depend on the header MUST gate on this rather
+ * than on a hand-written height query, otherwise they will disagree with the
+ * SCSS at the boundary pixel.
+ */
+export const PAGE_HEADER_HIDDEN_QUERY = `(max-height: ${PAGE_HEADER_HIDDEN_MAX_HEIGHT_PX}px)`;
+
+/**
+ * Matches when `Navigation` is rendering its mobile layout.
+ *
+ * Anything that portals into the mobile nav bar must gate on this exact query
+ * so the portal target is guaranteed to be mounted.
+ */
+export const MOBILE_NAV_QUERY = `(max-width: ${MOBILE_NAV_MAX_WIDTH_PX}px)`;

--- a/acarshub-react/src/utils/navActionSlot.ts
+++ b/acarshub-react/src/utils/navActionSlot.ts
@@ -1,0 +1,105 @@
+// Copyright (C) 2022-2026 Frederick Clausen II
+// This file is part of acarshub <https://github.com/sdr-enthusiasts/docker-acarshub>.
+
+// acarshub is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// acarshub is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with acarshub.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Mobile navigation action-slot registry.
+ *
+ * The mobile nav bar exposes one slot, to the right of the msg/min widget,
+ * into which the *active page* may project a single high-priority action. On
+ * short-and-narrow viewports there is nowhere else for such an action to live:
+ * `.page__header` is hidden below 800px viewport height, and the page's own
+ * control rows are too cramped at phone widths to also carry it.
+ *
+ * WHY a module-level registry rather than React context:
+ * `Navigation` is mounted as a sibling of the routed page tree, not an
+ * ancestor of it, so a provider would have to be hoisted to `App` and threaded
+ * down through every route. This mirrors `utils/scrollRegistry.ts`, which
+ * solves the identical "chrome outside the page tree needs a handle on
+ * something inside it" problem, and keeps the two consistent.
+ *
+ * WHY the page pushes into the nav rather than the nav pulling from the page:
+ * the nav has no knowledge of any page's actions, and must not grow a
+ * per-route switch statement. Ownership of the action — its label, its enabled
+ * condition, its handler — stays entirely with the page that defines it.
+ *
+ * Only one slot exists, and therefore only one action may occupy it at a time.
+ * That is deliberate: the slot is a scarce, high-value position, and silently
+ * stacking actions into it would reintroduce the overflow problem it exists to
+ * avoid. Because a route transition unmounts the previous page before the next
+ * one projects into the slot, single occupancy needs no arbitration.
+ */
+
+type Subscriber = (slot: HTMLElement | null) => void;
+
+/** The mounted slot element, or null when the mobile nav is not rendered. */
+let currentSlot: HTMLElement | null = null;
+
+/** Callbacks notified whenever the slot element is mounted or unmounted. */
+const subscribers = new Set<Subscriber>();
+
+/**
+ * Registers (or, with `null`, deregisters) the nav action slot element.
+ *
+ * Called by `Navigation` from a ref callback, so it fires exactly when the
+ * element attaches and detaches — including when the nav swaps between its
+ * mobile and desktop layouts, which unmounts the slot entirely.
+ *
+ * Subscribers are notified synchronously so a page projecting into the slot
+ * re-renders in the same commit phase and never paints a frame with its action
+ * missing.
+ */
+export function registerNavActionSlot(slot: HTMLElement | null): void {
+  currentSlot = slot;
+  for (const cb of subscribers) {
+    cb(currentSlot);
+  }
+}
+
+/**
+ * Returns the currently mounted nav action slot, or null when there is none.
+ *
+ * A null result is a normal state, not an error: the desktop nav has no slot
+ * because pages have room for their own actions at that width.
+ */
+export function getNavActionSlot(): HTMLElement | null {
+  return currentSlot;
+}
+
+/**
+ * Subscribes to slot mount/unmount changes.
+ *
+ * The callback is NOT invoked on subscription — read the current value with
+ * `getNavActionSlot()` for initial state, matching the convention established
+ * by `subscribeToScrollContainer`.
+ *
+ * Returns an unsubscribe function; call it from an effect cleanup.
+ */
+export function subscribeToNavActionSlot(cb: Subscriber): () => void {
+  subscribers.add(cb);
+  return () => {
+    subscribers.delete(cb);
+  };
+}
+
+/**
+ * Clears all registry state.
+ *
+ * FOR TESTING ONLY — production code must let mount/unmount drive the slot.
+ */
+export function _resetNavActionSlotForTesting(): void {
+  currentSlot = null;
+  subscribers.clear();
+}

--- a/acarshub-types/package.json
+++ b/acarshub-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acarshub/types",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "Shared TypeScript type definitions for ACARS Hub frontend and backend",
   "type": "module",
   "main": "./dist/index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acarshub-workspace",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acarshub-workspace",
-      "version": "4.2.1",
+      "version": "4.2.2",
       "license": "GPL-3.0-or-later",
       "workspaces": [
         "acarshub-types",
@@ -23,7 +23,7 @@
     },
     "acarshub-backend": {
       "name": "@acarshub/backend",
-      "version": "4.2.1",
+      "version": "4.2.2",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@acarshub/types": "*",
@@ -88,7 +88,7 @@
       }
     },
     "acarshub-react": {
-      "version": "4.2.1",
+      "version": "4.2.2",
       "dependencies": {
         "@acarshub/types": "*",
         "@tanstack/react-virtual": "3.14.9",
@@ -170,7 +170,7 @@
     },
     "acarshub-types": {
       "name": "@acarshub/types",
-      "version": "4.2.1",
+      "version": "4.2.2",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@biomejs/biome": "2.5.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "acarshub-workspace",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "private": true,
   "type": "module",
   "description": "ACARS Hub - Monorepo for frontend, backend, and shared types",


### PR DESCRIPTION
## Summary

The Alerts page hides `.page__header` below 800px viewport height. That is correct — the title and stat line are largely redundant with the nav bar, and the vertical space is worth more to the message list. But the header also carried the **Mark All Read** action, so hiding it removed the only way to clear unread alerts on any short viewport.

This PR keeps the action reachable at every viewport by relocating it rather than hiding it, and fixes two page-header layout issues found along the way.

## Placement matrix

Height is evaluated before width: the header is suppressed by a height query alone, so whenever it is on screen it is the right home — even on a narrow phone in portrait. Width only decides the fallback.

| Condition | Placement | Anchored |
| --- | --- | --- |
| height > 800px | `page-header` | Right of stats (unchanged) |
| height <= 800px, width >= 768px | `controls-bar` | Far right of the Live/Historical row |
| height <= 800px, width <= 767px | `nav-slot` | Right of the msg/min widget |

Every row below is an actual passing E2E assertion in a real browser:

| Viewport | W x H | Placement |
| --- | --- | --- |
| Desktop 1080p | 1920x1080 | `page-header` |
| Laptop tall | 1280x900 | `page-header` |
| Tablet portrait | 768x1024 | `page-header` |
| Phone portrait tall | 390x844 | `page-header` |
| **Height boundary** | 1280x**801** | `page-header` |
| **Height boundary** | 1280x**800** | `controls-bar` |
| Laptop 720p | 1280x720 | `controls-bar` |
| Tablet landscape | 1024x768 | `controls-bar` |
| Phone landscape wide | 844x390 | `controls-bar` |
| **Width boundary** | **768**x720 | `controls-bar` |
| **Width boundary** | **767**x720 | `nav-slot` |
| Phone landscape | 667x375 | `nav-slot` |
| Phone portrait short | 390x664 | `nav-slot` |
| Small phone | 320x568 | `nav-slot` |

No compromise was needed at small phone sizes: at 320px the msg/min widget is already hidden (it needs 375px), so the nav row has room and the button keeps its full 44x44px touch target.

## Design decisions

**The nav-slot placement is a React portal, not CSS.** The nav bar is a sibling of the routed page, so no stylesheet can move the button there. `utils/navActionSlot.ts` is a module-level registry mirroring the existing `scrollRegistry` pattern: the page publishes an action into nav chrome outside its own tree while keeping ownership of the handler and enabled condition. `Navigation` never learns what Alerts is.

**Exactly one instance is ever rendered.** Rendering all three and hiding two with media queries is simpler, but puts three identically-named buttons in the accessibility tree — breaking screen-reader navigation and `getByRole` for tests alike.

**Thresholds live in one place.** The 800px and 767px values mirror CSS that governs whether the target container is on screen at all, so `utils/breakpoints.ts` holds them and a unit test parses the SCSS to prove the mirror still holds. Drift there is otherwise invisible: the action would land in a `display: none` container while every render test still passed.

## Also fixed

- **Mark All Read was 15px shorter than the mode buttons** it sits beside in the `controls-bar` placement. Now matched via `align-self: stretch`, so the row height stays the single source of truth and the two cannot silently decouple when either is adjusted.
- **`.page__title` was roughly double the height of everything beside it** — 1.5rem rising to 1.875rem at >=768px, against 1rem stats and a 0.875rem button. Now 1rem flat. Still an `<h1>`, so the document outline and screen-reader heading navigation are unchanged; weight and colour keep it distinct. `.page__subtitle` is pinned to 0.875rem so it does not become identical in size to the title on About.
- **Search Database had ~45% more vertical chrome than every other page** (77px vs 57px at 1280x900). `.page` carried a top margin by default that every app-like page overrode back to zero — Live Messages and Alerts explicitly, Stats via `margin: 0 auto auto auto`, Live Map via `margin: 0 !important`. Search was the one page that never got the override. Rather than add a fifth, the default is inverted: `.page` is now flush and About (a document, not a tool surface) opts in explicitly.

### Pre-existing bug fixed in passing

`font-size: var(--font-size-base)` on the Mark All Read button referenced a token that does not exist — the theme layer defines `--font-size-md`. The declaration silently resolved to nothing and the button inherited its size. Corrected as the rule was being rewritten, with a regression test.

## Testing

- **54 new unit tests** covering the placement rule (including all four boundary pixels), the slot registry, the portal hook, and the DOM wiring.
- **21 E2E cases across 14 real viewports** asserting visibility, correct anchor, single instance, in-viewport bounds, clickability, equal height with the mode buttons, the 44px touch floor, live resize, unmount cleanup, and absence in historical mode.
- **10 E2E cases** pinning header chrome consistency across pages.

E2E rather than unit for the layout assertions because the failure mode is visual, not structural: the button is in the DOM in every case; what breaks is whether an ancestor is `display: none`, whether it is clipped, or whether it overlaps the msg/min widget. jsdom has no layout engine and reports every element as visible with a zero-sized box.

**Mutation-tested.** Each new suite was verified to fail when its fix is reverted — forcing the header placement unconditionally fails 6 tests; removing `align-self: stretch` reproduces the 15px delta exactly; restoring the old `.page` margin fails 7 of 10 header-consistency cases.

Each of the four commits was verified green in isolation, so `git bisect` stays usable.

| Gate | Result |
| --- | --- |
| `just ci` | green |
| Frontend unit | 2407 passed |
| Backend unit | 1316 passed |
| E2E (5 browsers) | 708 passed |

## Notes

- Version bumped 4.2.1 -> 4.2.2 across the workspace root and all three packages.
- `@axe-core/playwright` shows as outdated (4.12.1 -> 4.13.0) but is **deliberately not updated**: it is in Renovate's `playwright` group, pinned and bumped as a unit with `@playwright/test` and the Playwright Docker image. Updating it alone would desync the assertion library from the container the E2E suite runs in.
