### PR TITLE
feat(db): migration 16 — v4.3 session tables and decoder search index (Phase 1)

### DIFF
--- a/acarshub-backend/src/db/__tests__/migrate-fts-repair.test.ts
+++ b/acarshub-backend/src/db/__tests__/migrate-fts-repair.test.ts
@@ -678,7 +678,11 @@ describe("migration04 FTS creation and repair", () => {
       .get() as { version_num: string } | undefined;
     db2.close();
 
-    expect(version?.version_num).toBe("8c9d47f5ed13");
+    // Was "8c9d47f5ed13" (migration15) before migration16
+    // (v43_session_and_decode_tables) landed; update this alongside
+    // db/migrations/index.ts's LATEST_REVISION whenever a new migration is
+    // appended.
+    expect(version?.version_num).toBe("4d2a7c918f3b");
   });
 });
 
@@ -755,13 +759,17 @@ describe("migration10 rebuild_fts", () => {
 
   // -------------------------------------------------------------------------
 
-  test("regression: alembic_version is 8c9d47f5ed13 after all migrations", () => {
+  test("regression: alembic_version is the latest revision after all migrations", () => {
+    // Was "8c9d47f5ed13" (migration15) before migration16
+    // (v43_session_and_decode_tables) landed; update this alongside
+    // db/migrations/index.ts's LATEST_REVISION whenever a new migration is
+    // appended.
     const db = new Database(DB_PATH);
     const version = db
       .prepare("SELECT version_num FROM alembic_version")
       .get() as { version_num: string } | undefined;
     db.close();
 
-    expect(version?.version_num).toBe("8c9d47f5ed13");
+    expect(version?.version_num).toBe("4d2a7c918f3b");
   });
 });

--- a/acarshub-backend/src/db/__tests__/migrate-initial-state.test.ts
+++ b/acarshub-backend/src/db/__tests__/migrate-initial-state.test.ts
@@ -339,7 +339,11 @@ describe("Migration from initial Alembic state", () => {
       .get() as { version_num: string } | undefined;
 
     expect(version).toBeDefined();
-    expect(version?.version_num).toBe("8c9d47f5ed13");
+    // Was "8c9d47f5ed13" (migration15) before migration16
+    // (v43_session_and_decode_tables) landed; update this alongside
+    // db/migrations/index.ts's LATEST_REVISION whenever a new migration is
+    // appended.
+    expect(version?.version_num).toBe("4d2a7c918f3b");
 
     testDb.close();
   });

--- a/acarshub-backend/src/db/__tests__/migrate-orchestrator.test.ts
+++ b/acarshub-backend/src/db/__tests__/migrate-orchestrator.test.ts
@@ -184,6 +184,11 @@ describe("runMigrations() orchestrator", () => {
     expect(tableNames.has("alert_matches")).toBe(true); // migration 8
     expect(tableNames.has("timeseries_stats")).toBe(true); // migration 11
     expect(tableNames.has("rrd_import_registry")).toBe(true); // migration 11
+    expect(tableNames.has("aircraft")).toBe(true); // migration 16
+    expect(tableNames.has("decoder_variant")).toBe(true); // migration 16
+    expect(tableNames.has("decoded_field")).toBe(true); // migration 16
+    expect(tableNames.has("decoded_messages")).toBe(true); // migration 16
+    expect(tableNames.has("system_config")).toBe(true); // migration 16
   });
 
   it("triggers VACUUM/ANALYZE when FTS is stale even though no migrations ran", () => {

--- a/acarshub-backend/src/db/__tests__/migration16.test.ts
+++ b/acarshub-backend/src/db/__tests__/migration16.test.ts
@@ -1,0 +1,792 @@
+// Copyright (C) 2022-2026 Frederick Clausen II
+// This file is part of acarshub <https://github.com/sdr-enthusiasts/docker-acarshub>.
+
+// acarshub is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// acarshub is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with acarshub.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Dedicated test suite for migration 16 (v43_session_and_decode_tables).
+ *
+ * migration16.ts's header comment documents four load-bearing shape
+ * decisions (AUTOINCREMENT on aircraft.id, exactly one performance index,
+ * NO ACTION on messages.session_id's FK, decode_level as INTEGER). This
+ * file pins every one of those decisions plus the ones documented in
+ * agent-docs/V4.3.md ("aircraft - Flight Session Registry", "Session
+ * Identifier Type", "decoded_messages - Decoded Text Storage") so that a
+ * future refactor of the migration cannot silently drift from the
+ * evidence-backed design without a test failing.
+ *
+ * Follows the same pattern as schema.test.ts / migrate-orchestrator.test.ts:
+ * runMigrations() is run once against a temp *file* database (not `:memory:` —
+ * runMigrations() opens its own connection by path, and a `:memory:`
+ * database is per-connection, so a separate inspection connection would
+ * never see the migrated schema). Because that database is shared by every
+ * test, and closing a connection does not undo committed writes to a file,
+ * each test's connection is wrapped in a transaction that afterEach rolls
+ * back. That is what keeps the suite order-independent.
+ *
+ * Critical detail (see migrate.ts:223): runMigrations() opens a bare
+ * connection with no pragmas, so `foreign_keys` is OFF during and after
+ * migration. Only the app's runtime connection (client.ts:134) turns it
+ * on. Every test in the "Foreign keys" section below opens its own
+ * connection and explicitly runs `db.pragma("foreign_keys = ON")` (and
+ * asserts it took effect) before relying on FK enforcement or cascade
+ * behaviour — otherwise the constraint would silently not fire and the
+ * test would pass for the wrong reason.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Database from "better-sqlite3";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { runMigrations } from "../migrate.js";
+import { migration16_v43Tables } from "../migrations/migration16.js";
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+let dbPath: string;
+
+beforeAll(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "acarshub-migration16-"));
+  dbPath = join(tmpDir, "test.db");
+  runMigrations(dbPath);
+});
+
+afterAll(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// All tests share one migrated temp *file* database, because running the full
+// migration chain per test would dominate the suite's runtime. Closing a
+// connection does NOT undo committed writes to a file database, so isolation
+// comes from wrapping each test's connection in a transaction that afterEach
+// always rolls back. Without this, a test that inserts a row would leak it
+// into every later test and the suite would be order-dependent.
+let db: Database.Database | undefined;
+
+afterEach(() => {
+  if (db) {
+    // inTransaction guards the tests that open no connection at all.
+    if (db.inTransaction) db.exec("ROLLBACK");
+    db.close();
+    db = undefined;
+  }
+});
+
+function openConnection(): Database.Database {
+  db = new Database(dbPath);
+  db.exec("BEGIN");
+  return db;
+}
+
+function openConnectionWithForeignKeys(): Database.Database {
+  // PRAGMA foreign_keys is a no-op inside a transaction, so it must be set
+  // before BEGIN rather than by reusing openConnection().
+  db = new Database(dbPath);
+  db.pragma("foreign_keys = ON");
+  // Guard against the exact hour-costing mistake this file is designed to
+  // avoid: assert the pragma actually took effect rather than trusting the
+  // call silently no-opped.
+  expect(db.pragma("foreign_keys", { simple: true })).toBe(1);
+  db.exec("BEGIN");
+  return db;
+}
+
+interface RealColumn {
+  cid: number;
+  name: string;
+  type: string;
+  notnull: number;
+  dflt_value: string | null;
+  pk: number;
+}
+
+function getColumns(conn: Database.Database, table: string): RealColumn[] {
+  return conn.prepare(`PRAGMA table_info(${table})`).all() as RealColumn[];
+}
+
+interface ForeignKeyRow {
+  id: number;
+  seq: number;
+  table: string;
+  from: string;
+  to: string;
+  on_update: string;
+  on_delete: string;
+  match: string;
+}
+
+function getForeignKeys(
+  conn: Database.Database,
+  table: string,
+): ForeignKeyRow[] {
+  return conn
+    .prepare(`PRAGMA foreign_key_list(${table})`)
+    .all() as ForeignKeyRow[];
+}
+
+function getTableSql(conn: Database.Database, table: string): string {
+  const row = conn
+    .prepare(
+      "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?",
+    )
+    .get(table) as { sql: string } | undefined;
+  if (!row) {
+    throw new Error(`table '${table}' not found in sqlite_master`);
+  }
+  return row.sql;
+}
+
+// ---------------------------------------------------------------------------
+// Schema shape
+// ---------------------------------------------------------------------------
+
+describe("migration 16: schema shape", () => {
+  it("creates all five new tables", () => {
+    const conn = openConnection();
+    const tables = conn
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name",
+      )
+      .all() as Array<{ name: string }>;
+    const names = new Set(tables.map((t) => t.name));
+
+    expect(names.has("aircraft")).toBe(true);
+    expect(names.has("decoder_variant")).toBe(true);
+    expect(names.has("decoded_field")).toBe(true);
+    expect(names.has("decoded_messages")).toBe(true);
+    expect(names.has("system_config")).toBe(true);
+  });
+
+  it("aircraft columns match the intended DDL, including defaults", () => {
+    const conn = openConnection();
+    const columns = getColumns(conn, "aircraft");
+    const byName = new Map(columns.map((c) => [c.name, c]));
+
+    expect(byName.get("id")).toMatchObject({
+      type: "INTEGER",
+      notnull: 0,
+      pk: 1,
+    });
+    expect(byName.get("icao_hex")).toMatchObject({ type: "TEXT", notnull: 0 });
+    expect(byName.get("callsign")).toMatchObject({ type: "TEXT", notnull: 0 });
+    expect(byName.get("tail")).toMatchObject({ type: "TEXT", notnull: 0 });
+    expect(byName.get("first_seen")).toMatchObject({
+      type: "INTEGER",
+      notnull: 1,
+    });
+    expect(byName.get("last_seen")).toMatchObject({
+      type: "INTEGER",
+      notnull: 1,
+    });
+
+    const isActive = byName.get("is_active");
+    expect(isActive).toMatchObject({ type: "INTEGER", notnull: 1 });
+    expect(isActive?.dflt_value).toBe("1");
+
+    const sessionType = byName.get("session_type");
+    expect(sessionType).toMatchObject({ type: "TEXT", notnull: 1 });
+    expect(sessionType?.dflt_value).toBe("'adsb'");
+
+    expect(byName.get("pairing_method")).toMatchObject({
+      type: "TEXT",
+      notnull: 0,
+    });
+
+    const traceState = byName.get("trace_state");
+    expect(traceState).toMatchObject({ type: "TEXT", notnull: 1 });
+    expect(traceState?.dflt_value).toBe("'none'");
+  });
+
+  it("decoder_variant.decoder_name is NOT NULL with an empty-string default", () => {
+    const conn = openConnection();
+    const columns = getColumns(conn, "decoder_variant");
+    const byName = new Map(columns.map((c) => [c.name, c]));
+
+    const decoderName = byName.get("decoder_name");
+    expect(decoderName).toMatchObject({ type: "TEXT", notnull: 1 });
+    expect(decoderName?.dflt_value).toBe("''");
+
+    expect(byName.get("decoder_version")).toMatchObject({
+      type: "TEXT",
+      notnull: 1,
+    });
+    const description = byName.get("description");
+    expect(description).toMatchObject({ type: "TEXT", notnull: 1 });
+    expect(description?.dflt_value).toBe("''");
+    expect(byName.get("id")).toMatchObject({
+      type: "INTEGER",
+      notnull: 0,
+      pk: 1,
+    });
+  });
+
+  it("decoded_messages is a compact index carrying no decoded text", () => {
+    const conn = openConnection();
+    const columns = getColumns(conn, "decoded_messages");
+    const byName = new Map(columns.map((c) => [c.name, c]));
+
+    expect(byName.get("message_id")).toMatchObject({
+      type: "INTEGER",
+      pk: 1,
+    });
+    expect(byName.get("variant_id")).toMatchObject({
+      type: "INTEGER",
+      notnull: 1,
+    });
+    expect(byName.get("mask_lo")).toMatchObject({
+      type: "INTEGER",
+      notnull: 1,
+    });
+    expect(byName.get("mask_hi")).toMatchObject({
+      type: "INTEGER",
+      notnull: 1,
+    });
+
+    // The absence of a decoded-text column is a deliberate, measured decision
+    // (~28 MB vs ~634 MB at 11M messages for ~95% of the search value), not an
+    // oversight. Adding one later is a 5 ms ALTER, so there is no need to
+    // pre-emptively reserve it. See agent-docs/V4.3.md "Open Question 7".
+    expect(columns.map((c) => c.name).sort()).toEqual([
+      "mask_hi",
+      "mask_lo",
+      "message_id",
+      "variant_id",
+    ]);
+  });
+
+  it("decoded_field assigns a stable bit position bounded to the mask width", () => {
+    const conn = openConnection();
+    const columns = getColumns(conn, "decoded_field");
+    const byName = new Map(columns.map((c) => [c.name, c]));
+
+    expect(byName.get("id")).toMatchObject({ type: "INTEGER", pk: 1 });
+    expect(byName.get("label")).toMatchObject({ type: "TEXT", notnull: 1 });
+  });
+
+  it("system_config columns match the intended DDL", () => {
+    const conn = openConnection();
+    const columns = getColumns(conn, "system_config");
+    const byName = new Map(columns.map((c) => [c.name, c]));
+
+    expect(byName.get("key")).toMatchObject({ type: "TEXT", pk: 1 });
+    expect(byName.get("value")).toMatchObject({
+      type: "TEXT",
+      notnull: 1,
+    });
+    expect(byName.get("updated_at")).toMatchObject({
+      type: "INTEGER",
+      notnull: 1,
+    });
+  });
+
+  it("decoded_messages, decoded_field and system_config are WITHOUT ROWID tables", () => {
+    // PRAGMA table_info does not expose WITHOUT ROWID; it must be read back
+    // from the stored DDL in sqlite_master.
+    const conn = openConnection();
+    expect(getTableSql(conn, "decoded_messages")).toMatch(/WITHOUT ROWID/i);
+    expect(getTableSql(conn, "decoded_field")).toMatch(/WITHOUT ROWID/i);
+    expect(getTableSql(conn, "system_config")).toMatch(/WITHOUT ROWID/i);
+  });
+
+  it("aircraft and decoder_variant are ordinary rowid tables, not WITHOUT ROWID", () => {
+    const conn = openConnection();
+    expect(getTableSql(conn, "aircraft")).not.toMatch(/WITHOUT ROWID/i);
+    expect(getTableSql(conn, "decoder_variant")).not.toMatch(
+      /WITHOUT ROWID/i,
+    );
+  });
+
+  it.each([
+    ["aircraft", "id"],
+    ["decoder_variant", "id"],
+    ["decoded_field", "id"],
+    ["decoded_messages", "message_id"],
+    ["system_config", "key"],
+  ] as const)(
+    "table '%s' has '%s' as its sole primary key column",
+    (table, expectedPk) => {
+      const conn = openConnection();
+      const pkColumns = getColumns(conn, table).filter((c) => c.pk > 0);
+      expect(pkColumns).toHaveLength(1);
+      expect(pkColumns[0]?.name).toBe(expectedPk);
+    },
+  );
+
+  it("messages.session_id exists, is INTEGER, and is nullable", () => {
+    const conn = openConnection();
+    const columns = getColumns(conn, "messages");
+    const sessionId = columns.find((c) => c.name === "session_id");
+    expect(sessionId).toBeDefined();
+    expect(sessionId?.type).toBe("INTEGER");
+    expect(sessionId?.notnull).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Foreign keys — every test here MUST enable foreign_keys explicitly. See
+// file header and agent-docs/V4.3.md "Session Identifier Type" for why
+// runMigrations() leaves it off and the app's runtime connection turns it
+// on separately.
+// ---------------------------------------------------------------------------
+
+describe("migration 16: foreign keys", () => {
+  it("declares decoded_messages.message_id -> messages(id) ON DELETE CASCADE and variant_id -> decoder_variant(id)", () => {
+    const conn = openConnection();
+    const fks = getForeignKeys(conn, "decoded_messages");
+
+    const messageFk = fks.find((fk) => fk.from === "message_id");
+    expect(messageFk).toMatchObject({
+      table: "messages",
+      to: "id",
+      on_delete: "CASCADE",
+    });
+
+    const variantFk = fks.find((fk) => fk.from === "variant_id");
+    expect(variantFk).toMatchObject({
+      table: "decoder_variant",
+      to: "id",
+    });
+  });
+
+  it("declares messages.session_id -> aircraft(id) with ON DELETE NO ACTION", () => {
+    // NO ACTION is deliberate, not the default falling through unexamined:
+    // ON DELETE CASCADE here would delete *messages* when a session is
+    // pruned — see migration16.ts point 3 and V4.3.md "Session Identifier
+    // Type".
+    const conn = openConnection();
+    const fks = getForeignKeys(conn, "messages");
+    const sessionFk = fks.find((fk) => fk.from === "session_id");
+
+    expect(sessionFk).toMatchObject({
+      table: "aircraft",
+      to: "id",
+      on_delete: "NO ACTION",
+    });
+  });
+
+  it("cascades: deleting a messages row removes its decoded_messages row", () => {
+    const conn = openConnectionWithForeignKeys();
+
+    const messageId = insertMessage(conn);
+    insertDecoderChain(conn, messageId);
+
+    conn.prepare("DELETE FROM messages WHERE id = ?").run(messageId);
+
+    const decoded = conn
+      .prepare("SELECT message_id FROM decoded_messages WHERE message_id = ?")
+      .get(messageId);
+    expect(decoded).toBeUndefined();
+  });
+
+  it("throws deleting an aircraft row that still has a referencing message", () => {
+    const conn = openConnectionWithForeignKeys();
+
+    const sessionId = insertAircraft(conn);
+    insertMessage(conn, sessionId);
+
+    expect(() => {
+      conn.prepare("DELETE FROM aircraft WHERE id = ?").run(sessionId);
+    }).toThrow(/FOREIGN KEY constraint failed/);
+  });
+
+  it("succeeds deleting the referencing message first, then the aircraft row", () => {
+    // This is the ordering Phase 6's session-prune must follow: messages
+    // before aircraft. See V4.3.md "Session Identifier Type".
+    const conn = openConnectionWithForeignKeys();
+
+    const sessionId = insertAircraft(conn);
+    const messageId = insertMessage(conn, sessionId);
+
+    conn.prepare("DELETE FROM messages WHERE id = ?").run(messageId);
+    expect(() => {
+      conn.prepare("DELETE FROM aircraft WHERE id = ?").run(sessionId);
+    }).not.toThrow();
+
+    const gone = conn
+      .prepare("SELECT id FROM aircraft WHERE id = ?")
+      .get(sessionId);
+    expect(gone).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Constraints
+// ---------------------------------------------------------------------------
+
+describe("migration 16: constraints", () => {
+  it("decoded_field rejects a bit position outside the mask width", () => {
+    // 126 bits are addressable across mask_lo/mask_hi. 64 labels existed in
+    // production at the time of writing, so there is roughly double the
+    // headroom — but a decoder release that pushes past the ceiling must fail
+    // loudly here rather than silently truncating a field out of the mask.
+    const conn = openConnection();
+
+    expect(() => {
+      conn
+        .prepare("INSERT INTO decoded_field (id, label) VALUES (?, ?)")
+        .run(125, "highest-addressable-bit");
+    }).not.toThrow();
+
+    for (const badId of [126, -1]) {
+      expect(() => {
+        conn
+          .prepare("INSERT INTO decoded_field (id, label) VALUES (?, ?)")
+          .run(badId, `out-of-range-${badId}`);
+      }).toThrow(/CHECK constraint failed/);
+    }
+  });
+
+  it("decoded_field label is unique so a bit position is never assigned twice", () => {
+    const conn = openConnection();
+    conn
+      .prepare("INSERT INTO decoded_field (id, label) VALUES (?, ?)")
+      .run(40, "Outside Air Temperature (C)");
+
+    expect(() => {
+      conn
+        .prepare("INSERT INTO decoded_field (id, label) VALUES (?, ?)")
+        .run(41, "Outside Air Temperature (C)");
+    }).toThrow(/UNIQUE constraint failed/);
+  });
+
+  it("a field-presence mask round-trips across the 63-bit column boundary", () => {
+    // The split into two columns is the whole reason this table can address
+    // more than 63 fields, so the boundary is the interesting case: bit 62 is
+    // the top of mask_lo and field id 63 is bit 0 of mask_hi.
+    const conn = openConnectionWithForeignKeys();
+    const messageId = insertMessage(conn);
+    const variantId = insertDecoderVariant(conn, "masker", "1.0.0");
+
+    const lo = 1n << 62n;
+    const hi = 1n << 0n;
+    conn
+      .prepare(
+        "INSERT INTO decoded_messages (message_id, variant_id, mask_lo, mask_hi) VALUES (?, ?, ?, ?)",
+      )
+      .run(messageId, variantId, lo, hi);
+
+    const found = conn
+      .prepare(
+        "SELECT message_id FROM decoded_messages WHERE (mask_lo & ?) != 0 AND (mask_hi & ?) != 0",
+      )
+      .get(lo, hi) as { message_id: number } | undefined;
+
+    expect(found?.message_id).toBe(messageId);
+
+    // A field the message does not carry must not match.
+    const absent = conn
+      .prepare("SELECT message_id FROM decoded_messages WHERE (mask_lo & ?) != 0")
+      .get(1n << 5n);
+    expect(absent).toBeUndefined();
+  });
+
+  it("regression: a second 'no decoder matched' variant cannot be created for the same version", () => {
+    // This is the exact bug the empty-string sentinel exists to prevent, so
+    // the test must exercise the path that was broken rather than a
+    // superficially similar one.
+    //
+    // decoder_name was originally nullable. SQLite treats NULLs as DISTINCT
+    // under UNIQUE, so the nullable design allowed unlimited duplicate
+    // (NULL, version) rows, and the natural find-or-create lookup
+    // `WHERE decoder_name = ?` matched nothing when the parameter was NULL.
+    // Every non-decoding message — 60% of text-bearing traffic, per
+    // agent-docs/V4.3.md — would have minted a fresh variant row instead of
+    // reusing one, destroying the interning this table exists to provide.
+    //
+    // Note what this test deliberately does NOT do: insert the literal ''
+    // twice. That version of this test was vacuous, because two identical
+    // non-NULL values collide under UNIQUE in the broken schema too, so it
+    // passed with or without the fix. The discriminating path is inserting
+    // *without naming the column*, which is what a find-or-create for "no
+    // decoder matched" actually does: under the fix the DEFAULT '' applies
+    // and the second insert collides; under the old schema both rows got
+    // NULL and both were accepted.
+    const conn = openConnection();
+
+    conn
+      .prepare("INSERT INTO decoder_variant (decoder_version) VALUES ('9.9.9')")
+      .run();
+
+    expect(() => {
+      conn
+        .prepare(
+          "INSERT INTO decoder_variant (decoder_version) VALUES ('9.9.9')",
+        )
+        .run();
+    }).toThrow(/UNIQUE constraint failed/);
+
+    // And the column rejects NULL outright, so the distinct-NULLs loophole
+    // cannot be reached by an explicit NULL either.
+    expect(() => {
+      conn
+        .prepare(
+          "INSERT INTO decoder_variant (decoder_name, decoder_version) VALUES (NULL, '9.9.8')",
+        )
+        .run();
+    }).toThrow(/NOT NULL constraint failed/);
+  });
+
+  it("enforces decoded_messages.variant_id against decoder_variant(id)", () => {
+    const conn = openConnectionWithForeignKeys();
+    const messageId = insertMessage(conn);
+
+    expect(() => {
+      conn
+        .prepare(
+          "INSERT INTO decoded_messages (message_id, variant_id) VALUES (?, ?)",
+        )
+        .run(messageId, 999_999);
+    }).toThrow(/FOREIGN KEY constraint failed/);
+  });
+
+  it("blocks deleting a decoder_variant row that is still referenced", () => {
+    // The variant table is an interned lookup; rows are never expected to be
+    // deleted. NO ACTION (the default) means an accidental delete fails loudly
+    // rather than leaving decoded_messages pointing at a missing variant.
+    const conn = openConnectionWithForeignKeys();
+    const messageId = insertMessage(conn);
+    const variantId = insertDecoderVariant(conn, "held-open", "2.0.0");
+
+    conn
+      .prepare(
+        "INSERT INTO decoded_messages (message_id, variant_id) VALUES (?, ?)",
+      )
+      .run(messageId, variantId);
+
+    expect(() => {
+      conn.prepare("DELETE FROM decoder_variant WHERE id = ?").run(variantId);
+    }).toThrow(/FOREIGN KEY constraint failed/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Idempotency
+// ---------------------------------------------------------------------------
+
+describe("migration 16: idempotency", () => {
+  it("applying migration 16 a second time is a no-op rather than an error", () => {
+    // Deliberately calls migration16_v43Tables() directly instead of going
+    // through runMigrations(). runMigrations() short-circuits on
+    // alembic_version and never reaches the migration loop on a second call,
+    // so driving it through the orchestrator would satisfy the phrase "run it
+    // twice" while never executing the CREATE TABLE IF NOT EXISTS and
+    // session_id guards that idempotency actually depends on.
+    const localDir = mkdtempSync(join(tmpdir(), "acarshub-migration16-idem-"));
+    const localDbPath = join(localDir, "test.db");
+    try {
+      runMigrations(localDbPath);
+
+      const conn = new Database(localDbPath);
+      try {
+        expect(() => {
+          migration16_v43Tables(conn);
+        }).not.toThrow();
+
+        // A second ALTER TABLE would add a duplicate column or throw.
+        const sessionIdColumns = getColumns(conn, "messages").filter(
+          (c) => c.name === "session_id",
+        );
+        expect(sessionIdColumns).toHaveLength(1);
+
+        // The tables and the index must survive the replay unchanged.
+        expect(
+          getColumns(conn, "decoder_variant").map((c) => c.name),
+        ).toEqual(["id", "decoder_name", "decoder_version", "description"]);
+        const indexInfo = conn
+          .prepare("PRAGMA index_info(ix_aircraft_active_hex)")
+          .all() as Array<{ name: string }>;
+        expect(indexInfo.map((c) => c.name)).toEqual([
+          "is_active",
+          "icao_hex",
+        ]);
+      } finally {
+        conn.close();
+      }
+    } finally {
+      rmSync(localDir, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses to run against a database whose tables drifted from this migration", () => {
+    // v4.3 migrations are editable until release, so a developer can hold a
+    // database created by an earlier draft. CREATE TABLE IF NOT EXISTS would
+    // silently accept the stale shape and setAlembicVersion would then mark
+    // the database migrated, hiding the drift permanently. The shape check in
+    // migration16.ts converts that into a loud, actionable failure.
+    const localDir = mkdtempSync(join(tmpdir(), "acarshub-migration16-drift-"));
+    const localDbPath = join(localDir, "test.db");
+    try {
+      const conn = new Database(localDbPath);
+      try {
+        // The exact historical drift: decoder_name nullable instead of
+        // NOT NULL DEFAULT ''.
+        conn.exec(`
+          CREATE TABLE decoder_variant (
+              id              INTEGER PRIMARY KEY AUTOINCREMENT,
+              decoder_name    TEXT,
+              decoder_version TEXT NOT NULL
+          );
+        `);
+
+        expect(() => {
+          migration16_v43Tables(conn);
+        }).toThrow(/decoder_variant.*NOT NULL=0, expected 1/s);
+      } finally {
+        conn.close();
+      }
+    } finally {
+      rmSync(localDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Index discipline
+// ---------------------------------------------------------------------------
+
+describe("migration 16: index discipline", () => {
+  it("ix_aircraft_active_hex exists on aircraft(is_active, icao_hex) in that column order", () => {
+    const conn = openConnection();
+    const indexInfo = conn
+      .prepare("PRAGMA index_info(ix_aircraft_active_hex)")
+      .all() as Array<{ seqno: number; name: string }>;
+
+    expect(indexInfo.map((c) => c.name)).toEqual(["is_active", "icao_hex"]);
+  });
+
+  it.each(["ix_aircraft_last_seen", "ix_decoded_version_level"])(
+    "regression: '%s' does not exist — both were measured and rejected",
+    (indexName) => {
+      // ix_aircraft_last_seen: zero query plans selected it even for the
+      // expiry sweep it was added for. ix_decoded_version_level: costs
+      // ~206 MB at 11M rows and speeds up nothing sargable. See
+      // migration16.ts's header comment (point 2) and V4.3.md "Exactly One
+      // Index, and Why the Second Was Dropped". This test exists to stop
+      // either from being "helpfully" reintroduced without new measurement.
+      const conn = openConnection();
+      const row = conn
+        .prepare("SELECT name FROM sqlite_master WHERE type = 'index' AND name = ?")
+        .get(indexName);
+      expect(row).toBeUndefined();
+    },
+  );
+
+  it("no index on the four new tables duplicates its table's primary key column list", () => {
+    const conn = openConnection();
+    const newTables: ReadonlyArray<[string, string[]]> = [
+      ["aircraft", ["id"]],
+      ["decoder_variant", ["id"]],
+      ["decoded_field", ["id"]],
+      ["decoded_messages", ["message_id"]],
+      ["system_config", ["key"]],
+    ];
+
+    for (const [table, pkColumns] of newTables) {
+      const indexes = conn
+        .prepare(`PRAGMA index_list(${table})`)
+        .all() as Array<{ name: string; origin: string }>;
+
+      // WITHOUT ROWID tables (decoded_messages, system_config) report their
+      // clustering primary key itself as an index with origin='pk' — that
+      // is the table's storage, not a redundant extra index, so it is
+      // excluded here. Only explicitly `CREATE INDEX`-created indexes
+      // (origin='c') are checked for duplicating the PK column list.
+      for (const { name } of indexes.filter((i) => i.origin === "c")) {
+        const indexColumns = (
+          conn.prepare(`PRAGMA index_info(${name})`).all() as Array<{
+            name: string;
+          }>
+        ).map((c) => c.name);
+
+        expect(
+          indexColumns,
+          `index '${name}' on '${table}' must not duplicate the primary key column list ${JSON.stringify(pkColumns)}`,
+        ).not.toEqual(pkColumns);
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Row fixture helpers (used by the foreign-key and constraint tests above)
+// ---------------------------------------------------------------------------
+
+let nextMessageId = 1;
+
+function insertMessage(
+  conn: Database.Database,
+  sessionId?: number,
+): number {
+  const id = nextMessageId++;
+  // messages carries a long tail of NOT NULL text(32) columns from the
+  // original Alembic schema (see drizzle/0000_unknown_phalanx.sql); this
+  // fixture only cares about id/msg_time/session_id, so every other NOT
+  // NULL column gets an empty-string placeholder.
+  conn
+    .prepare(
+      `INSERT INTO messages (
+         id, message_type, msg_time, station_id, toaddr, fromaddr,
+         depa, dsta, eta, gtout, gtin, wloff, wlin, lat, lon, alt,
+         msg_text, tail, flight, icao, freq, ack, mode, label,
+         block_id, msgno, is_response, is_onground, error, libacars, level,
+         session_id
+       ) VALUES (
+         ?, 'ACARS', ?, '', '', '', '', '', '', '', '', '', '', '', '', '',
+         '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', ?
+       )`,
+    )
+    .run(id, Math.floor(Date.now() / 1000), sessionId ?? null);
+  return id;
+}
+
+function insertAircraft(conn: Database.Database): number {
+  const now = Math.floor(Date.now() / 1000);
+  const result = conn
+    .prepare(
+      "INSERT INTO aircraft (icao_hex, first_seen, last_seen) VALUES (?, ?, ?)",
+    )
+    .run("ABC123", now, now);
+  return Number(result.lastInsertRowid);
+}
+
+function insertDecoderVariant(
+  conn: Database.Database,
+  name: string,
+  version: string,
+  description = "",
+): number {
+  const result = conn
+    .prepare(
+      "INSERT INTO decoder_variant (decoder_name, decoder_version, description) VALUES (?, ?, ?)",
+    )
+    .run(name, version, description);
+  return Number(result.lastInsertRowid);
+}
+
+function insertDecoderChain(conn: Database.Database, messageId: number): void {
+  const variantId = insertDecoderVariant(
+    conn,
+    "test-decoder",
+    `1.0.0-${messageId}`,
+  );
+  conn
+    .prepare(
+      "INSERT INTO decoded_messages (message_id, variant_id) VALUES (?, ?)",
+    )
+    .run(messageId, variantId);
+}

--- a/acarshub-backend/src/db/__tests__/schema.test.ts
+++ b/acarshub-backend/src/db/__tests__/schema.test.ts
@@ -74,6 +74,11 @@ const ALL_TABLES: ReadonlyArray<Table> = [
   schema.ignoreAlertTerms,
   schema.timeseriesStats,
   schema.rrdImportRegistry,
+  schema.aircraft,
+  schema.decoderVariant,
+  schema.decodedField,
+  schema.decodedMessages,
+  schema.systemConfig,
 ];
 
 // Every explicitly-named index declared in schema.ts's `(table) => ({...})`
@@ -97,6 +102,13 @@ const EXPECTED_INDEXES: readonly string[] = [
   "ix_alert_matches_term_time",
   "ix_alert_matches_id_term",
   "idx_rrd_import_registry_hash",
+  "ix_aircraft_active_hex",
+  // Uniqueness constraints on small lookup tables, not performance indexes.
+  // Declared as named indexes rather than inline UNIQUE so they are pinned
+  // here instead of drifting under auto-generated sqlite_autoindex names,
+  // and so they can be widened later without rebuilding the table.
+  "ix_decoder_variant_key",
+  "ix_decoded_field_label",
 ];
 
 // ---------------------------------------------------------------------------
@@ -188,6 +200,11 @@ describe("db/schema.ts smoke test (TEST-GAP-BE)", () => {
       ["alert_matches", "id"],
       ["timeseries_stats", "timestamp"],
       ["rrd_import_registry", "id"],
+      ["aircraft", "id"],
+      ["decoder_variant", "id"],
+      ["decoded_field", "id"],
+      ["decoded_messages", "message_id"],
+      ["system_config", "key"],
     ] as const)(
       "table '%s' has '%s' as its primary key",
       (tableName, expectedPkColumn) => {

--- a/acarshub-backend/src/db/migrations/index.ts
+++ b/acarshub-backend/src/db/migrations/index.ts
@@ -17,6 +17,7 @@
 // 13. 96f36b89016d - drop_unnecessary_indexes
 // 14. 803398f85958 - remove_uuid
 // 15. 8c9d47f5ed13 - drop_unnecessary_indexes2
+// 16. 4d2a7c918f3b - v43_session_and_decode_tables
 //
 // This barrel assembles the ordered MIGRATIONS array from the individual
 // per-migration modules (one file per revision) and derives LATEST_REVISION
@@ -39,6 +40,7 @@ import { migration12_dropResolutionPromoteTimestampPk } from "./migration12.js";
 import { migration13_dropUnnecessaryIndexes } from "./migration13.js";
 import { migration14_removeUuid } from "./migration14.js";
 import { migration15_dropUnnecessaryIndexes2 } from "./migration15.js";
+import { migration16_v43Tables } from "./migration16.js";
 import type { MigrationStep } from "./types.js";
 
 export {
@@ -134,6 +136,11 @@ export const MIGRATIONS: MigrationStep[] = [
     revision: "8c9d47f5ed13",
     name: "drop_unnecessary_indexes2",
     upgrade: migration15_dropUnnecessaryIndexes2,
+  },
+  {
+    revision: "4d2a7c918f3b",
+    name: "v43_session_and_decode_tables",
+    upgrade: migration16_v43Tables,
   },
 ];
 

--- a/acarshub-backend/src/db/migrations/migration16.ts
+++ b/acarshub-backend/src/db/migrations/migration16.ts
@@ -1,0 +1,297 @@
+// ----------------------------------------------------------------------------
+// Migration 16: v43_session_and_decode_tables (4d2a7c918f3b)
+//
+// Adds the storage v4.3 Phase 1 needs: the `aircraft` session registry, the
+// `decoder_variant` / `decoded_field` / `decoded_messages` decoder search
+// index, the `system_config` key-value store, and `messages.session_id`. Does
+// NOT add `aircraft_positions` — that table is deferred to migration 17
+// (Phase 8), see agent-docs/V4.3.md "Why the Split".
+//
+// Every shape below is settled by measurement against a production database,
+// not assumption — see agent-docs/V4.3.md for the full evidence. The four
+// points that matter most for a future reader of this file:
+//
+// 1. `aircraft.id` is AUTOINCREMENT, deliberately. A plain INTEGER PRIMARY
+//    KEY reuses the rowids of deleted rows, so once session pruning lands a
+//    stale `messages.session_id` could silently re-point at a *different*,
+//    newer session. AUTOINCREMENT makes a dangling reference stay dangling
+//    instead of becoming a wrong one.
+//
+// 2. Exactly ONE performance index is created here: `ix_aircraft_active_hex`.
+//    `ix_aircraft_last_seen` and `ix_decoded_version_level` were both
+//    measured and explicitly rejected (zero query plans selected the
+//    former even for the expiry sweep it was added for; the latter costs
+//    ~206 MB at 11M rows and speeds up nothing sargable). Do not
+//    "helpfully" add either back without new measurement.
+//    `ix_decoder_variant_name_version` is also created, but it enforces a
+//    uniqueness constraint on a 42-row lookup table — it is correctness,
+//    not a performance index, and is not subject to the same test.
+//
+// 3. `messages.session_id` carries a FK to `aircraft(id)` with the default
+//    `NO ACTION` — this is deliberate. `ON DELETE CASCADE` must NEVER be
+//    used on this column: it would delete *messages* when a session is
+//    pruned, which is the exact failure mode this schema exists to avoid.
+//
+// 4. `decoded_messages` stores NO decoded text. It is a compact search
+//    index — message-type classification plus a field-presence bitmask —
+//    measured at ~28 MB per 11M messages against ~634 MB for storing
+//    decoded text with an FTS index over it, for ~95% of the search value.
+//    Decoded text for display is produced on read (0.008 ms/decode), which
+//    also means a displayed decode can never be stale. Expanding to
+//    free-text search later is additive and cheap: ADD COLUMN is 5 ms and
+//    CREATE VIRTUAL TABLE ... USING fts5 touches nothing, both verified at
+//    4.2M rows. See agent-docs/V4.3.md "Open Question 7".
+// ----------------------------------------------------------------------------
+
+import type Database from "better-sqlite3";
+import { createLogger } from "../../utils/logger.js";
+
+const logger = createLogger("db:migrate-16");
+
+interface ExpectedColumn {
+  name: string;
+  type: "INTEGER" | "TEXT";
+  notnull: 0 | 1;
+}
+
+/**
+ * `CREATE TABLE IF NOT EXISTS` silently accepts a table that already exists
+ * with a *different* shape, which matters more than usual here: v4.3's
+ * migrations are editable until the release ships (see agent-docs/V4.3.md
+ * "Migrations Under This Plan Are Mutable Until v4.3 Ships"), so a developer
+ * who applied an earlier draft of this migration and then pulls a corrected
+ * one has a database whose tables do not match this file. Without this check
+ * the migration would complete, `setAlembicVersion` would stamp the database
+ * as migrated, and the drift would survive silently.
+ *
+ * Column name, declared type and NOT NULL are compared — nullability
+ * specifically, because the one real drift this has already had to catch
+ * (`decoder_name` nullable vs NOT NULL) leaves the column names identical.
+ */
+function assertTableShape(
+  db: Database.Database,
+  table: string,
+  expected: readonly ExpectedColumn[],
+): void {
+  const actual = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{
+    name: string;
+    type: string;
+    notnull: number;
+  }>;
+
+  const actualByName = new Map(actual.map((c) => [c.name, c]));
+  const drift: string[] = [];
+
+  for (const column of expected) {
+    const found = actualByName.get(column.name);
+    if (!found) {
+      drift.push(`missing column '${column.name}'`);
+      continue;
+    }
+    if (found.type.toUpperCase() !== column.type) {
+      drift.push(
+        `column '${column.name}' is declared ${found.type || "(no type)"}, expected ${column.type}`,
+      );
+    }
+    if (found.notnull !== column.notnull) {
+      drift.push(
+        `column '${column.name}' has NOT NULL=${found.notnull}, expected ${column.notnull}`,
+      );
+    }
+  }
+
+  const expectedNames = new Set(expected.map((c) => c.name));
+  for (const column of actual) {
+    if (!expectedNames.has(column.name)) {
+      drift.push(`unexpected column '${column.name}'`);
+    }
+  }
+
+  if (drift.length > 0) {
+    throw new Error(
+      `Table '${table}' already exists with a shape this migration did not create: ` +
+        `${drift.join("; ")}. This normally means a pre-release draft of migration 16 ` +
+        "was applied to this database. v4.3 migrations are editable until release, so " +
+        "the fix is to discard this development database and re-migrate from scratch.",
+    );
+  }
+}
+
+export function migration16_v43Tables(db: Database.Database): void {
+  logger.warn("Applying migration 16: v43_session_and_decode_tables");
+
+  const migrate = db.transaction(() => {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS aircraft (
+          id             INTEGER PRIMARY KEY AUTOINCREMENT,
+          icao_hex       TEXT,
+          callsign       TEXT,
+          tail           TEXT,
+          first_seen     INTEGER NOT NULL,
+          last_seen      INTEGER NOT NULL,
+          is_active      INTEGER NOT NULL DEFAULT 1,
+          session_type   TEXT    NOT NULL DEFAULT 'adsb',
+          pairing_method TEXT,
+          trace_state    TEXT    NOT NULL DEFAULT 'none'
+      )
+    `);
+
+    assertTableShape(db, "aircraft", [
+      { name: "id", type: "INTEGER", notnull: 0 },
+      { name: "icao_hex", type: "TEXT", notnull: 0 },
+      { name: "callsign", type: "TEXT", notnull: 0 },
+      { name: "tail", type: "TEXT", notnull: 0 },
+      { name: "first_seen", type: "INTEGER", notnull: 1 },
+      { name: "last_seen", type: "INTEGER", notnull: 1 },
+      { name: "is_active", type: "INTEGER", notnull: 1 },
+      { name: "session_type", type: "TEXT", notnull: 1 },
+      { name: "pairing_method", type: "TEXT", notnull: 0 },
+      { name: "trace_state", type: "TEXT", notnull: 1 },
+    ]);
+
+    db.exec(
+      "CREATE INDEX IF NOT EXISTS ix_aircraft_active_hex ON aircraft(is_active, icao_hex)",
+    );
+
+    // `decoder_name` is NOT NULL with an empty-string sentinel for "no decoder
+    // matched", rather than nullable. This is not a style choice. SQLite treats
+    // NULLs as distinct in a UNIQUE constraint, so a nullable column would (a)
+    // allow unlimited duplicate (NULL, version) rows and (b) make the natural
+    // find-or-create lookup `WHERE decoder_name = ?` match nothing when the
+    // parameter is NULL. The result would be one new variant row per
+    // non-decoding message — 60% of text-bearing traffic — which destroys the
+    // interning this table exists to provide.
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS decoder_variant (
+          id              INTEGER PRIMARY KEY AUTOINCREMENT,
+          decoder_name    TEXT NOT NULL DEFAULT '',
+          decoder_version TEXT NOT NULL,
+          description     TEXT NOT NULL DEFAULT ''
+      )
+    `);
+
+    assertTableShape(db, "decoder_variant", [
+      { name: "id", type: "INTEGER", notnull: 0 },
+      { name: "decoder_name", type: "TEXT", notnull: 1 },
+      { name: "decoder_version", type: "TEXT", notnull: 1 },
+      { name: "description", type: "TEXT", notnull: 1 },
+    ]);
+
+    // Declared as a named unique index rather than an inline UNIQUE table
+    // constraint. Two reasons, and the second is the one that matters later:
+    // it appears in sqlite_master under a predictable name so EXPECTED_INDEXES
+    // in db/__tests__/schema.test.ts can pin it, and a named index can be
+    // widened with DROP INDEX + CREATE UNIQUE INDEX, whereas SQLite cannot
+    // alter an inline table constraint without rebuilding the whole table.
+    // Do not "tidy" this back into an inline UNIQUE(...).
+    //
+    // `description` is part of the key because it is not quite a function of
+    // the plugin: 39 of 41 observed plugins emit exactly one description, but
+    // `arinc-702` emits 26 and `label-13-18-slash` emits 5. Keying on the
+    // triple yields ~70 rows — still a single page.
+    db.exec(
+      `CREATE UNIQUE INDEX IF NOT EXISTS ix_decoder_variant_key
+         ON decoder_variant(decoder_name, decoder_version, description)`,
+    );
+
+    // Stable label -> bit-position assignment for decoded_messages.mask_*.
+    // This table is what makes the bitmask meaningful across restarts: if bit
+    // positions were assigned in discovery order at runtime they would differ
+    // between processes and every stored mask would decode to the wrong set of
+    // fields. `id` IS the bit position, so rows are never renumbered or
+    // deleted — a retired field simply leaves its bit permanently unused.
+    //
+    // The 0-125 bound is the capacity of the two 63-bit halves below. 64
+    // distinct labels were observed in production, so there is headroom for
+    // roughly double before this needs a third column; the CHECK makes hitting
+    // that ceiling a loud failure rather than silent truncation.
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS decoded_field (
+          id    INTEGER PRIMARY KEY CHECK(id BETWEEN 0 AND 125),
+          label TEXT NOT NULL
+      ) WITHOUT ROWID
+    `);
+
+    assertTableShape(db, "decoded_field", [
+      { name: "id", type: "INTEGER", notnull: 1 },
+      { name: "label", type: "TEXT", notnull: 1 },
+    ]);
+
+    db.exec(
+      `CREATE UNIQUE INDEX IF NOT EXISTS ix_decoded_field_label
+         ON decoded_field(label)`,
+    );
+
+    // Compact search index over decoder output. Deliberately stores no decoded
+    // text: measurement against a production corpus showed that ~95% of the
+    // search value is message-type classification (`decoder_variant.description`,
+    // e.g. "Ground Station Squitter" — 0 hits in raw text, 39,535 decoded) plus
+    // which fields a message carries, and that storing decoded text plus an FTS
+    // index to make it searchable costs ~9x more for the remaining ~5%. See
+    // agent-docs/V4.3.md "Open Question 7". Decoded text for *display* is
+    // produced on read, which also means it can never be stale.
+    //
+    // A row exists only for messages that actually decoded, so absence means
+    // "no decoder output", not "not yet processed".
+    //
+    // mask_lo/mask_hi are a 126-bit field-presence set split across two
+    // integers because SQLite's INTEGER is signed 64-bit and there were already
+    // 64 distinct labels in production — one column would have been at capacity
+    // on day one. Bit n of mask_lo is decoded_field id n; bit n of mask_hi is
+    // decoded_field id n + 63.
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS decoded_messages (
+          message_id INTEGER PRIMARY KEY REFERENCES messages(id) ON DELETE CASCADE,
+          variant_id INTEGER NOT NULL REFERENCES decoder_variant(id),
+          mask_lo    INTEGER NOT NULL DEFAULT 0,
+          mask_hi    INTEGER NOT NULL DEFAULT 0
+      ) WITHOUT ROWID
+    `);
+
+    // Note `message_id` is notnull=1: in a WITHOUT ROWID table the primary key
+    // is implicitly NOT NULL, unlike a rowid-alias INTEGER PRIMARY KEY (which
+    // reports notnull=0, as `aircraft.id` and `decoder_variant.id` do above).
+    assertTableShape(db, "decoded_messages", [
+      { name: "message_id", type: "INTEGER", notnull: 1 },
+      { name: "variant_id", type: "INTEGER", notnull: 1 },
+      { name: "mask_lo", type: "INTEGER", notnull: 1 },
+      { name: "mask_hi", type: "INTEGER", notnull: 1 },
+    ]);
+
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS system_config (
+          key        TEXT    PRIMARY KEY,
+          value      TEXT    NOT NULL,
+          updated_at INTEGER NOT NULL
+      ) WITHOUT ROWID
+    `);
+
+    // `key` is notnull=1 for the same WITHOUT ROWID reason as decoded_messages.
+    assertTableShape(db, "system_config", [
+      { name: "key", type: "TEXT", notnull: 1 },
+      { name: "value", type: "TEXT", notnull: 1 },
+      { name: "updated_at", type: "INTEGER", notnull: 1 },
+    ]);
+
+    // SQLite has no "ADD COLUMN IF NOT EXISTS", so guard by hand against
+    // running this migration twice.
+    const messageColumns = db
+      .prepare("PRAGMA table_info(messages)")
+      .all() as Array<{ name: string }>;
+    const hasSessionId = messageColumns.some(
+      (col) => col.name === "session_id",
+    );
+
+    if (hasSessionId) {
+      logger.warn("messages.session_id already exists, skipping ALTER");
+    } else {
+      db.exec(
+        "ALTER TABLE messages ADD COLUMN session_id INTEGER REFERENCES aircraft(id)",
+      );
+    }
+  });
+
+  migrate();
+
+  logger.warn("✓ Migration 16 complete");
+}

--- a/acarshub-backend/src/db/queries/__tests__/alerts.test.ts
+++ b/acarshub-backend/src/db/queries/__tests__/alerts.test.ts
@@ -104,7 +104,8 @@ const CREATE_ALERT_TABLES = `
     error        TEXT NOT NULL DEFAULT '',
     libacars     TEXT NOT NULL DEFAULT '',
     level        TEXT NOT NULL DEFAULT '',
-    aircraft_id  TEXT
+    aircraft_id  TEXT,
+    session_id   INTEGER
   );
 
   CREATE TABLE IF NOT EXISTS alert_matches (

--- a/acarshub-backend/src/db/queries/__tests__/messageTransform.test.ts
+++ b/acarshub-backend/src/db/queries/__tests__/messageTransform.test.ts
@@ -76,7 +76,8 @@ describe("Message Transformation", () => {
         error TEXT NOT NULL,
         libacars TEXT NOT NULL,
         level TEXT NOT NULL,
-        aircraft_id TEXT
+        aircraft_id TEXT,
+        session_id INTEGER
       );
 
       CREATE TABLE IF NOT EXISTS alert_stats (

--- a/acarshub-backend/src/db/queries/__tests__/statistics.test.ts
+++ b/acarshub-backend/src/db/queries/__tests__/statistics.test.ts
@@ -128,7 +128,8 @@ const CREATE_STATS_TABLES = `
     error        TEXT NOT NULL DEFAULT '',
     libacars     TEXT NOT NULL DEFAULT '',
     level        TEXT NOT NULL DEFAULT '',
-    aircraft_id  TEXT
+    aircraft_id  TEXT,
+    session_id   INTEGER
   );
 `;
 

--- a/acarshub-backend/src/db/queries/messages/__tests__/messages.test.ts
+++ b/acarshub-backend/src/db/queries/messages/__tests__/messages.test.ts
@@ -91,7 +91,8 @@ describe("Message Query Functions", () => {
         error INTEGER,
         libacars TEXT,
         level REAL,
-        aircraft_id TEXT
+        aircraft_id TEXT,
+        session_id INTEGER
       );
 
       CREATE VIRTUAL TABLE messages_fts USING fts5(
@@ -959,6 +960,85 @@ describe("Message Query Functions", () => {
         )
         .get() as { c: number };
       expect(remaining.c).toBe(PROTECTED_COUNT);
+    });
+
+    it("regression: migration 16's first foreign key (decoded_messages -> messages ON DELETE CASCADE) does not change pruneDatabase()'s behaviour", () => {
+      // Migration 16 (v4.3 Phase 1) introduced this schema's first foreign
+      // keys. pruneDatabase() deletes from `messages` first and
+      // `alert_matches` second (see prune.ts) — that ordering was chosen
+      // for the SQLITE_MAX_VARIABLE_NUMBER reason in the test above, before
+      // any FK existed. This test proves the ordering still produces the
+      // same delete counts now that a `messages` delete can fan out via
+      // cascade: decoded_messages.message_id -> messages(id) ON DELETE
+      // CASCADE has nothing to do with `alert_matches` (no FK relationship
+      // between them), so pruning alert_matches second is unaffected either
+      // way, but the message-first ordering matters because it's what lets
+      // the decoded_messages cascade fire as a side effect of the exact
+      // same DELETE statement pruneDatabase already issues, with no extra
+      // application code required.
+      //
+      // This file's fixture predates migration 16 (see file header) and
+      // does not run the real migration chain, so decoder_variant/
+      // decoded_messages are added by hand here. runMigrations() itself
+      // never sets `foreign_keys = ON` (migrate.ts:223); only the app's
+      // runtime connection does (client.ts:134). This test enables it
+      // explicitly on the same connection pruneDatabase's mocked
+      // getDatabase() wraps, so the cascade actually fires instead of
+      // silently no-opping.
+      db.pragma("foreign_keys = ON");
+      expect(db.pragma("foreign_keys", { simple: true })).toBe(1);
+
+      db.exec(`
+        CREATE TABLE decoder_variant (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          decoder_name TEXT NOT NULL DEFAULT '',
+          decoder_version TEXT NOT NULL,
+          description TEXT NOT NULL DEFAULT ''
+        );
+        CREATE TABLE decoded_messages (
+          message_id INTEGER PRIMARY KEY REFERENCES messages(id) ON DELETE CASCADE,
+          variant_id INTEGER NOT NULL REFERENCES decoder_variant(id),
+          mask_lo    INTEGER NOT NULL DEFAULT 0,
+          mask_hi    INTEGER NOT NULL DEFAULT 0
+        ) WITHOUT ROWID;
+      `);
+
+      const now = Math.floor(Date.now() / 1000);
+      const old = now - 10 * 86400; // outside the 7-day message window
+      const uid = 88123456;
+      insertMessage(uid, old);
+
+      const variantId = db
+        .prepare(
+          "INSERT INTO decoder_variant (decoder_name, decoder_version, description) VALUES ('mcdu', '1.0', 'Fault Log Report') RETURNING id",
+        )
+        .get() as { id: number };
+      db.prepare(
+        "INSERT INTO decoded_messages (message_id, variant_id, mask_lo) VALUES (?, ?, 1)",
+      ).run(uid, variantId.id);
+
+      // Assert on the specific UID rather than a total count, matching the
+      // rest of this describe block: the 4 beforeEach messages are pruned in
+      // the same run, so a hardcoded total would break whenever the shared
+      // fixture changes, for reasons unrelated to this regression.
+      //
+      // The discriminating assertion is that this call does not throw. If the
+      // cascade were downgraded to the FK default, deleting a message with a
+      // decoded_messages child would raise FOREIGN KEY constraint failed and
+      // pruneDatabase() would propagate it.
+      const { prunedMessages } = pruneDatabase(7, 30);
+
+      expect(prunedMessages).toBeGreaterThanOrEqual(1);
+
+      const decodedGone = db
+        .prepare("SELECT message_id FROM decoded_messages WHERE message_id = ?")
+        .get(uid);
+      expect(decodedGone).toBeUndefined();
+
+      const messageGone = db
+        .prepare("SELECT id FROM messages WHERE id = ?")
+        .get(uid);
+      expect(messageGone).toBeUndefined();
     });
   });
 

--- a/acarshub-backend/src/db/queries/messages/search.ts
+++ b/acarshub-backend/src/db/queries/messages/search.ts
@@ -257,6 +257,7 @@ function mapRawRowToMessage(row: Record<string, unknown>): Message {
     libacars: row.libacars as string,
     level: row.level as string,
     aircraftId: (row.aircraft_id as string | null) ?? null,
+    sessionId: (row.session_id as number | null) ?? null,
   };
 }
 

--- a/acarshub-backend/src/db/schema.ts
+++ b/acarshub-backend/src/db/schema.ts
@@ -83,7 +83,8 @@ export const messages = sqliteTable(
     error: text("error", { length: 32 }).notNull(),
     libacars: text("libacars").notNull(),
     level: text("level", { length: 32 }).notNull(),
-    aircraftId: text("aircraft_id", { length: 36 }), // Added in migration 8, nullable for future use
+    aircraftId: text("aircraft_id", { length: 36 }), // Added in migration 8, nullable for future use; dead column, never written, superseded by sessionId
+    sessionId: integer("session_id"), // Added in migration 16; FK to aircraft(id), NO ACTION on delete — see aircraft table comment below
   },
   (table) => ({
     // Single-column indexes. depa/dsta/flight/freq/label/tail were dropped
@@ -354,6 +355,146 @@ export const rrdImportRegistry = sqliteTable(
 );
 
 // ============================================================================
+// v4.3 Session and Decode Tables (Migration 16)
+// ============================================================================
+
+/**
+ * Flight session registry.
+ *
+ * Each row is one flight session; two appearances of the same aircraft are
+ * two rows (see agent-docs/V4.3.md "Session Lifecycle"). `id` is the FK
+ * target for `messages.sessionId` and is AUTOINCREMENT so a pruned session's
+ * rowid is never reused — reuse would let a stale `messages.session_id`
+ * silently re-point at a different, newer session.
+ *
+ * Exactly one index exists here: `ix_aircraft_active_hex`. A second index on
+ * `last_seen` (`ix_aircraft_last_seen`) was measured and rejected — see
+ * migration16.ts and agent-docs/V4.3.md for the numbers. Do not add it back
+ * without new measurement.
+ *
+ * Drizzle cannot express `WITHOUT ROWID`; this table is a normal rowid table
+ * so that divergence does not apply here. The real DDL lives in
+ * migration16.ts — this file is not the source of truth (see the comment on
+ * the `messages` table above).
+ */
+export const aircraft = sqliteTable(
+  "aircraft",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    icaoHex: text("icao_hex"),
+    callsign: text("callsign"),
+    tail: text("tail"),
+    firstSeen: integer("first_seen").notNull(),
+    lastSeen: integer("last_seen").notNull(),
+    isActive: integer("is_active").notNull().default(1),
+    sessionType: text("session_type").notNull().default("adsb"),
+    pairingMethod: text("pairing_method"),
+    traceState: text("trace_state").notNull().default("none"),
+  },
+  (table) => ({
+    activeHexIdx: index("ix_aircraft_active_hex").on(
+      table.isActive,
+      table.icaoHex,
+    ),
+  }),
+);
+
+/**
+ * Interned `(decoder_name, decoder_version, description)` triples referenced
+ * by `decodedMessages.variantId`. Measured at ~70 distinct triples in
+ * production — a single 4 KB page. `description` is the searchable
+ * message-type name ("Ground Station Squitter", "Fault Log Report"); it lives
+ * here rather than per-message because it is nearly a function of the plugin,
+ * which is what makes message-type search cost almost nothing.
+ *
+ * The unique index below is also the lookup path for upsert-on-insert; there
+ * is no separate index beside it. It is a named index rather than an inline
+ * UNIQUE so it can be widened later without rebuilding the table.
+ */
+export const decoderVariant = sqliteTable(
+  "decoder_variant",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    // Empty-string sentinel, not NULL, for "no decoder matched". SQLite treats
+    // NULLs as distinct under UNIQUE, so a nullable column would permit
+    // duplicate rows and break find-or-create lookups. See migration16.ts.
+    decoderName: text("decoder_name").notNull().default(""),
+    decoderVersion: text("decoder_version").notNull(),
+    description: text("description").notNull().default(""),
+  },
+  (table) => ({
+    variantKeyIdx: uniqueIndex("ix_decoder_variant_key").on(
+      table.decoderName,
+      table.decoderVersion,
+      table.description,
+    ),
+  }),
+);
+
+/**
+ * Stable field-label to bit-position assignment for `decodedMessages.maskLo` /
+ * `maskHi`. `id` IS the bit position, so rows are never renumbered or deleted;
+ * a retired field leaves its bit permanently unused. Without this table the
+ * masks would be meaningless across restarts.
+ *
+ * Drizzle cannot express `WITHOUT ROWID` or the `CHECK(id BETWEEN 0 AND 125)`
+ * bound; migration16.ts carries both.
+ */
+export const decodedField = sqliteTable(
+  "decoded_field",
+  {
+    id: integer("id").primaryKey(), // bit position, 0-125
+    label: text("label").notNull(),
+  },
+  (table) => ({
+    labelIdx: uniqueIndex("ix_decoded_field_label").on(table.label),
+  }),
+);
+
+/**
+ * Compact search index over decoder output. A row exists only for messages
+ * that actually produced decoder output, so absence means "no decoder output",
+ * not "not yet processed".
+ *
+ * Deliberately stores NO decoded text: classification (`decoderVariant.
+ * description`) plus a field-presence bitmask carries ~95% of the measured
+ * search value at ~9x less storage than persisting decoded text with an FTS
+ * index over it. Decoded text for display is produced on read. See
+ * agent-docs/V4.3.md "Open Question 7".
+ *
+ * `maskLo` / `maskHi` are a 126-bit set of `decodedField.id` values, split
+ * across two columns because SQLite's INTEGER is signed 64-bit and 64 distinct
+ * labels already exist in production. Bit n of `maskLo` is field id n; bit n
+ * of `maskHi` is field id n + 63.
+ *
+ * Drizzle cannot express `WITHOUT ROWID`; migration16.ts is the source of
+ * truth for the on-disk DDL (see the comment on the `messages` table above).
+ * No index exists beside the primary key — `ix_decoded_version_level` was
+ * measured and rejected, see migration16.ts.
+ */
+export const decodedMessages = sqliteTable("decoded_messages", {
+  messageId: integer("message_id").primaryKey(), // REFERENCES messages(id) ON DELETE CASCADE
+  variantId: integer("variant_id").notNull(), // REFERENCES decoder_variant(id)
+  maskLo: integer("mask_lo").notNull().default(0), // decoded_field ids 0-62
+  maskHi: integer("mask_hi").notNull().default(0), // decoded_field ids 63-125
+});
+
+/**
+ * General-purpose persistent key-value store for values that must survive
+ * restarts and are not appropriate as environment variables (e.g. the
+ * installed decoder version, reprocessor status/cursor — see
+ * agent-docs/V4.3.md "system_config").
+ *
+ * Drizzle cannot express `WITHOUT ROWID`; migration16.ts is the source of
+ * truth for that attribute, as with `decodedMessages` above.
+ */
+export const systemConfig = sqliteTable("system_config", {
+  key: text("key").primaryKey(),
+  value: text("value").notNull(),
+  updatedAt: integer("updated_at").notNull(),
+});
+
+// ============================================================================
 // TypeScript Types (Inferred from Schema)
 // ============================================================================
 
@@ -386,3 +527,18 @@ export type NewTimeseriesStat = typeof timeseriesStats.$inferInsert;
 
 export type RrdImportRegistryEntry = typeof rrdImportRegistry.$inferSelect;
 export type NewRrdImportRegistryEntry = typeof rrdImportRegistry.$inferInsert;
+
+export type Aircraft = typeof aircraft.$inferSelect;
+export type NewAircraft = typeof aircraft.$inferInsert;
+
+export type DecoderVariant = typeof decoderVariant.$inferSelect;
+export type NewDecoderVariant = typeof decoderVariant.$inferInsert;
+
+export type DecodedField = typeof decodedField.$inferSelect;
+export type NewDecodedField = typeof decodedField.$inferInsert;
+
+export type DecodedMessage = typeof decodedMessages.$inferSelect;
+export type NewDecodedMessage = typeof decodedMessages.$inferInsert;
+
+export type SystemConfig = typeof systemConfig.$inferSelect;
+export type NewSystemConfig = typeof systemConfig.$inferInsert;

--- a/agent-docs/V4.3.md
+++ b/agent-docs/V4.3.md
@@ -520,7 +520,7 @@ The new tables are split across **two** migrations, deliberately:
 
 | Migration | Tables                                                                                          | Phase |
 | --------- | ----------------------------------------------------------------------------------------------- | ----- |
-| 16        | `aircraft`, `decoder_variant`, `decoded_messages`, `system_config`, `messages.session_id`        | 1     |
+| 16        | `aircraft`, `decoder_variant`, `decoded_field`, `decoded_messages`, `system_config`, `messages.session_id` | 1 |
 | 17        | `aircraft_positions`                                                                            | 8     |
 
 ### Why the Split
@@ -776,12 +776,18 @@ On-disk bytes, real corpus, VACUUMed, projected to 11M messages with a row on ev
 | `formatted` 2-tuples | 717 | -76% |
 | \+ variant lookup table | 640 | -78% |
 | \+ drop `decoded_at` | 586 | -80% |
-| \+ `decode_level` as INTEGER (**adopted**) | 542 | -82% |
-| \+ fold level into the variant key (rejected) | 530 | -82% |
+| \+ `decode_level` as INTEGER | 542 | -82% |
+| \+ fold level into the variant key | 530 | -82% |
+| **compact index, no decoded text (adopted)** | **~28** | **-99%** |
 
 Folding `decode_level` into the variant key saves a further 12 MB (2%) but makes a per-message
 outcome part of a decoder-identity row and turns every level-filtered query into a join. Not
 worth it for 2%.
+
+The last row is the shape actually adopted, and it is a different design rather than a further
+optimisation of this one: it stores no decoded text at all. The reasoning is in Open Question 7.
+The rows above are retained because they are the evidence that storing decoded text is
+expensive, and because a future decision to add free-text search will need them.
 
 `decoded_at` was dropped because nothing consumes it: the reprocessor keys on version, and
 sweep progress is tracked by `system_config.acars_decoder_reprocess_cursor`. It cost 54 MB at
@@ -792,54 +798,102 @@ sweep progress is tracked by `system_config.acars_decoder_reprocess_cursor`. It 
 ```sql
 CREATE TABLE decoder_variant (
     id              INTEGER PRIMARY KEY AUTOINCREMENT,
-    decoder_name    TEXT,               -- NULL when the message did not decode
+    decoder_name    TEXT NOT NULL DEFAULT '',   -- '' when no decoder matched
     decoder_version TEXT NOT NULL,
-    UNIQUE(decoder_name, decoder_version)
+    description     TEXT NOT NULL DEFAULT ''    -- searchable message-type name
 );
 
+CREATE UNIQUE INDEX ix_decoder_variant_key
+    ON decoder_variant(decoder_name, decoder_version, description);
+
+CREATE TABLE decoded_field (
+    id    INTEGER PRIMARY KEY CHECK(id BETWEEN 0 AND 125),  -- IS the bit position
+    label TEXT NOT NULL
+) WITHOUT ROWID;
+
+CREATE UNIQUE INDEX ix_decoded_field_label ON decoded_field(label);
+
 CREATE TABLE decoded_messages (
-    message_id   INTEGER PRIMARY KEY REFERENCES messages(id) ON DELETE CASCADE,
-    variant_id   INTEGER NOT NULL REFERENCES decoder_variant(id),
-    decode_level INTEGER NOT NULL CHECK(decode_level IN (0, 1, 2)),
-    decoded_json TEXT    -- NULL when decode_level = 0; otherwise a JSON array
-                         -- of [label, value] 2-tuples, rehydrated to
-                         -- DecodedTextItem[] on read
+    message_id INTEGER PRIMARY KEY REFERENCES messages(id) ON DELETE CASCADE,
+    variant_id INTEGER NOT NULL REFERENCES decoder_variant(id),
+    mask_lo    INTEGER NOT NULL DEFAULT 0,   -- decoded_field ids 0-62
+    mask_hi    INTEGER NOT NULL DEFAULT 0    -- decoded_field ids 63-125
 ) WITHOUT ROWID;
 ```
 
-`decode_level` is `0 = none`, `1 = partial`, `2 = full`. The integer encoding saves 44 MB at
-11M messages over the `TEXT` form and follows the precedent already set by `aircraft_positions`
-(`alt_25`, and its `-1` ground sentinel): integers with a documented mapping and a `CHECK`
-constraint, not human-readable strings on every row.
+**No decoded text is stored.** This is the outcome of Open Question 7 — see that section for
+the evidence. The table is a search index, not a cache: message-type classification plus which
+fields a message carries. Decoded text for *display* is produced on read, which costs 0.00836 ms
+and can never be stale.
 
-The 42 observed `(decoder_name, decoder_version)` pairs occupy a **single 4 KB page**. Interning
-them removes ~19 B/row of repeated text from a table that is 1:1 with `messages`. Its `UNIQUE`
-constraint is the lookup path for upsert-on-insert; there is no separate index beside it, so no
-duplicate B-tree.
+`decoder_name` is `NOT NULL` with an empty-string sentinel rather than nullable. SQLite treats
+NULLs as **distinct** under `UNIQUE`, so a nullable column would permit unlimited duplicate
+`(NULL, version)` rows and make the find-or-create lookup `WHERE decoder_name = ?` match nothing
+when the parameter is NULL — minting a fresh variant row for every non-decoding message and
+destroying the interning the table exists for.
+
+`description` is part of the variant key because it is *nearly*, but not quite, a function of
+the plugin: 39 of 41 observed plugins emit exactly one description, `arinc-702` emits 26 and
+`label-13-18-slash` emits 5. Keying on the triple gives **~70 rows, a single 4 KB page**, which
+is what makes message-type search essentially free.
+
+`decoded_field` is what makes the bitmask meaningful across restarts. `id` **is** the bit
+position, so rows are never renumbered or deleted; a retired field leaves its bit permanently
+unused. If bit positions were assigned in discovery order at runtime they would differ between
+processes and every stored mask would decode to the wrong set of fields.
+
+The mask is split across two columns because SQLite's `INTEGER` is signed 64-bit and **64
+distinct field labels already exist in production** — a single column would have been at
+capacity on day one. Two columns give 126 bits, roughly double the headroom, and the `CHECK`
+turns hitting that ceiling into a loud failure rather than silent truncation.
+
+Both unique constraints are declared as **named indexes** rather than inline `UNIQUE(...)`.
+That is deliberate twice over: named indexes can be pinned by `EXPECTED_INDEXES` in
+`db/__tests__/schema.test.ts` instead of drifting under an auto-generated `sqlite_autoindex_`
+name, and a named index can be widened with `DROP INDEX` + `CREATE UNIQUE INDEX`, whereas SQLite
+cannot alter an inline table constraint without rebuilding the whole table. Do not tidy them
+back into inline constraints.
 
 Keyed on `messages.id`, not a UUID, for the same reason as sessions. The relationship is 1:1,
 so `message_id` is the primary key directly. Under `WITHOUT ROWID` that primary key **is** the
 table, which also means the `ON DELETE CASCADE` from `messages` needs no extra index.
 
-#### Row Policy: Text-Bearing Messages Only
+#### Row Policy: Decoded Messages Only
 
-**Do not create a row for a message with empty `msg_text`.** No decoder version can ever decode
-a message with no text, so such a row would be a permanent placeholder that can never change.
-This saves 78 MB at 11M messages and makes the reprocessor's first pass meaningful:
+**A row exists only for a message that actually produced decoder output.** Absence therefore
+means "no decoder output", not "not yet processed". 61.7% of messages have no text at all and
+can never decode; a further 60.5% of text-bearing messages produce nothing. Only **15.1% of all
+messages** get a row.
 
 | State | Meaning |
 | ----- | ------- |
-| No row, `msg_text` empty | Nothing to decode, ever. Not a re-processing candidate. |
-| No row, `msg_text` non-empty | Never processed. This is re-processing pass 1. |
-| Row present | Processed; `variant_id` says by which decoder and version. |
+| No row, `msg_text` empty | Nothing to decode, ever. Never an index-rebuild candidate. |
+| No row, `msg_text` non-empty | Either did not decode, or not yet indexed — distinguished by the rebuild cursor, not by a stored row. |
+| Row present | Decoded; `variant_id` gives the decoder, version and message type. |
 
-This supersedes the original note that `decode_level = 'none'` rows exist to distinguish "never
-tried" from "tried and failed". That distinction is preserved — but only where it means
-something, which is text-bearing messages.
+At **17.39 B/row** this costs roughly **21 MB on the 3.36M-message production corpus and
+~28 MB at 11M messages** — against 896 MB and 2,933 MB for the plan as originally written.
 
-With this policy the adopted shape costs **142 MB on the 3.36M-message production corpus** and
-roughly **464 MB at 11M messages**, against 896 MB and 2,933 MB respectively for the plan as
-originally written.
+#### Expanding to Free-Text Search Later
+
+The compact design is a strict subset of the full one, and every route from here to there is
+additive. Verified at 4.2M rows:
+
+| Change | Cost | Rewrites existing rows? |
+| ------ | ---- | ----------------------- |
+| `ALTER TABLE decoded_messages ADD COLUMN decoded_json TEXT` | 5 ms | no — metadata only |
+| `CREATE VIRTUAL TABLE ... USING fts5(...)` | 0 ms | no — touches nothing |
+| Widen `ix_decoder_variant_key` | 0 ms | no |
+| Backfill every row | 1.4 s + ~92 s to decode | yes, but online and resumable |
+
+The likely expansion is an FTS5 table populated from decode-on-read, which needs no schema
+change at all. A `decoded_json` column with `LIKE` is **not** a viable search path: measured
+~66 ms per query and scaling linearly.
+
+The only changes that would need a table rebuild are altering `decoded_messages`'s primary key
+or its `WITHOUT ROWID` attribute. Neither has a plausible reason to change: `message_id` as the
+primary key is forced by the 1:1 relationship, and `WITHOUT ROWID` is what makes that key be the
+table.
 
 #### No `ix_decoded_version_level`
 
@@ -1396,7 +1450,8 @@ Phase numbering starts at 1. The original Phase 0 (documentation audit) is compl
 
 ### Phase 1: Database Migration 16
 
-Add `aircraft`, `decoder_variant`, `decoded_messages`, and `system_config` tables, plus
+Add `aircraft`, `decoder_variant`, `decoded_field`, `decoded_messages`, and `system_config`
+tables, plus
 `messages.session_id INTEGER REFERENCES aircraft(id)`. **Not** `aircraft_positions` — that is
 migration 17, Phase 8.
 
@@ -1408,14 +1463,16 @@ adopted DDL and the evidence behind it. Phase 1 creates the storage only — Pha
 
 - `db/migrations/migration16.ts` exporting `migration16_v43Tables`, registered in
   `db/migrations/index.ts`
-- Exactly one index across all four tables: `ix_aircraft_active_hex`. No
-  `ix_aircraft_last_seen`, no `ix_decoded_version_level` — both were measured and rejected.
-- Tests: fresh DB migration, idempotency (run twice), column/PK/type verification for all four
+- Exactly one *performance* index across all five tables: `ix_aircraft_active_hex`. No
+  `ix_aircraft_last_seen`, no `ix_decoded_version_level` — both were measured and rejected. The
+  two unique indexes on the lookup tables are correctness constraints, not performance indexes.
+- Tests: fresh DB migration, idempotency (run twice), column/PK/type verification for all five
   tables, `ON DELETE CASCADE` verified for `decoded_messages` -> `messages`
 - Test: `messages.session_id` foreign key is present and enforced — a `DELETE` from `aircraft`
   with a referencing message fails, and deleting the message first then the session succeeds
-- Test: `decode_level` `CHECK` rejects values outside 0-2; `decoder_variant`'s `UNIQUE` is
-  enforced
+- Test: `decoded_field.id` `CHECK` rejects a bit position outside 0-125; both lookup tables'
+  uniqueness is enforced, including for the `''` `decoder_name` sentinel; a field-presence mask
+  round-trips across the `mask_lo`/`mask_hi` boundary
 - Test: `EXPECTED_INDEXES` and `ALL_TABLES` in `db/__tests__/schema.test.ts` updated - they pin
   the index and table sets and will fail otherwise
 - Test: confirm no index duplicates a primary key
@@ -1433,31 +1490,38 @@ A typed wrapper around `system_config` table reads/writes. Used by all subsequen
 - `src/services/system-config.ts` with `get(key)`, `set(key, value)` functions
 - Tests: get/set round-trip, missing key returns null, updated_at is set
 
-### Phase 3: Decoded Messages Pipeline
+### Phase 3: Decoder Search Index
 
-Replace inline decode-and-attach with store-then-retrieve. Decoder version detection at
-startup triggers re-processing if the version changed.
-
-**Deliverables**:
-
-- `decoded_messages` written at ingest (new messages and on first retrieval of legacy messages)
-- All five retrieval paths listed above JOIN instead of re-decoding
-- Version comparison at startup in `server.ts`
-- Measurement: record `decoded_json` size per message on a real corpus before committing to
-  storing it verbatim
-- Tests: new message creates a row, retrieval uses stored decode, version change triggers
-  reprocessor schedule, ring-buffer warm-up performs no decodes when rows exist
-
-### Phase 4: Background Decoder Reprocessor
+Populate the compact decoder search index at ingest, and expose it to the Search page. Decoded
+text for display continues to be produced on read by `enrichMessage()` — this phase does **not**
+persist decoded text. See Open Question 7 for why.
 
 **Deliverables**:
 
-- `src/services/decoder-reprocessor.ts`
-- Cursor-based batch processing (250 messages per batch, yields between batches)
-- Resume on restart from `system_config` cursor
-- `decoder_reprocess_progress` and `message_decode_updated` socket events
-- Tests: processes in correct priority order, cursor is persisted, resumes after restart,
-  emits correct socket events when decode changes, does not block ingest under load
+- `decoded_field` seeded lazily: a label not yet present is assigned the next free bit position.
+  Assignment must be atomic and must never renumber an existing row.
+- `decoder_variant` find-or-create on `(decoder_name, decoder_version, description)`.
+- `decoded_messages` row written at ingest for every message that produces decoder output, with
+  `mask_lo` / `mask_hi` set from the field labels present.
+- Search backend supports filtering by message-type description and by field presence.
+- Tests: bit assignment is stable across restarts; a label at position 63 lands in `mask_hi`
+  not `mask_lo`; exhausting 126 bits fails loudly rather than truncating; a message with no
+  decoder output writes no row; variant find-or-create does not duplicate on the `''` sentinel.
+
+### Phase 4: Search Index Rebuild on Decoder Change
+
+Replaces the original background reprocessor, which existed only to repair stale *persisted
+decodes*. There are none — display decodes on read — so the only thing a decoder upgrade
+invalidates is the search index.
+
+**Deliverables**:
+
+- Version comparison at startup against `system_config.acars_decoder_installed_version`.
+- Cursor-driven rebuild over `messages.id`, batched and yielding between batches, resumable
+  from `system_config` after a restart. Measured cost: ~92 s of decode plus ~1.4 s of writes
+  for 4.2M rows.
+- Tests: cursor is persisted, rebuild resumes after restart, does not block ingest under load,
+  a version change triggers exactly one rebuild.
 
 ### Phase 5: Session Service
 
@@ -1735,55 +1799,97 @@ interpret the output.
 6. **Does `features_enabled` grow or get a sibling event?** It is typed as `Decoders`
    (`acarshub-types/src/system.ts:127-141`) and already carries non-decoder fields. Adding
    `ENABLE_POSITION_HISTORY` to it is precedented but semantically wrong.
-7. **Should decodes be persisted at all, or decoded on read?** (Blocks Phases 3 and 4.) See
-   below — this question was raised by measurement during Phase 1 and is not yet resolved.
+7. ~~**Should decodes be persisted at all, or decoded on read?**~~ **ANSWERED: both.** Display
+   decodes on read; persist a compact search index. See below. This resolved Phases 3 and 4 and
+   removed the reprocessor from the plan.
 
-### Is Persisting Decodes Worth Its Storage?
+### Is Persisting Decodes Worth Its Storage? (Answered)
 
-Measured on the production corpus with the real decoder, weighted over the actual mix of
-decode outcomes: **0.00836 ms per decode**. Counter-intuitively the messages that *fail* to
-decode are the slowest class (0.0111 ms), so a sample is not biased toward the flattering
-answer.
+**Answer: split display from search.** Decode on read for display; persist a compact
+classification index for search. Neither of the two options originally considered — "persist
+decoded text" and "do not persist" — was right.
 
-Against that, the re-decode sites the plan cites as justification for persisting:
+#### Decode Cost Is Not the Deciding Factor
 
-| Site | Decodes | Cost |
-| ---- | ------- | ---- |
-| Ring-buffer warm-up at startup | 700 | 5.85 ms |
-| Search returning 50 results | 50 | 0.42 ms |
-| Search returning 500 results | 500 | 4.18 ms |
-| Alert term search, 200 results | 200 | 1.67 ms |
+Decoding measures **0.00836 ms** on the production corpus, weighted over the real mix of
+outcomes. Counter-intuitively the messages that *fail* to decode are the slowest class
+(0.0111 ms), so the sample is not biased toward the flattering answer. Every re-decode site the
+plan cites as justification for persisting is trivial: ring-buffer warm-up 5.85 ms, a
+500-result search 4.18 ms.
 
-So the performance case for `decoded_messages` is worth roughly **6 ms at startup and 4 ms on
-a large search**, in exchange for ~464 MB at 11M messages and ~10% database growth. On its own
-that is a poor trade, and Storage Discipline says to surface it rather than absorb it.
+That makes decode-on-read viable for display, and it has a property persistence cannot match:
+**it is always current by construction.** A displayed decode can never be stale, so the
+staleness Phase 4 existed to repair is *created* by persistence rather than solved by it. "A new
+version of `@airframes/acars-decoder` silently leaves old messages undecoded" — one of the
+stated reasons v4.3 exists — is only true if decodes are persisted.
 
-The argument cuts deeper than storage. **Decode-on-read is always current by construction.** A
-retrieval path that decodes with the installed decoder can never return a stale decode, which
-means:
+But decode cost was the wrong question. The real one is search.
 
-- The staleness that Phase 4 exists to repair is *created* by Phase 3's persistence.
-- "A new version of `@airframes/acars-decoder` silently leaves old messages undecoded" — one of
-  the stated reasons v4.3 exists — is only true if decodes are persisted. Decode-on-read
-  upgrades all history the instant the package is bumped, for free.
-- Dropping persistence would remove the reprocessor, its cursor, all three
-  `acars_decoder_*` `system_config` keys, and the `message_decode_updated` and
-  `decoder_reprocess_progress` events.
+#### Search Is the Reason to Persist
 
-Arguments genuinely on the side of persisting, stated fairly:
+Decoded output contains a vocabulary that does not exist in raw ACARS text at all. Measured
+against the production corpus:
 
-1. **SQL-queryable decoded text.** FTS over decoded output, or alert matching against decoded
-   rather than raw text, requires persistence. Nothing does this today (alert matching runs on
-   raw text in `insert.ts:244-399`) and it is not in Additional Features, but retrofitting it
-   later would need a backfill.
-2. **Regression protection.** If a decoder upgrade makes a decode *worse*, persistence keeps
-   the previous good output. Decode-on-read would lose it silently.
-3. **Target hardware.** The timings above were taken on a development machine, not on the
-   Pi-class hosts adsb.im deploys to. Even assuming 10x slower, startup warm-up is ~58 ms and
-   a 500-result search ~42 ms, which is still small — but this has not been measured on the
-   real target.
+| Search-page query | hits today | hits with decoded indexed |
+| ----------------- | ---------- | ------------------------- |
+| `squitter` | **0** | 39,535 |
+| `ground station` | **0** | 39,535 |
+| `fault log` | **0** | 545 |
+| `position report` | 423 | 18,417 |
+| `temperature` | 55 | 14,943 |
+| `destination` | 95 | 11,049 |
+| `altitude` | 535 | 22,175 |
+| `flight plan` | 159 | 3,941 |
 
-Until this is resolved, `decoded_messages` and `decoder_variant` are specified above as
-measured, so that building them is cheap if the answer is "persist" and discarding them costs
-only a migration edit if it is not — see Migrations Under This Plan Are Mutable Until v4.3
-Ships.
+There are **49 distinct message-type descriptions**, nearly all appearing zero times in raw
+text, and 64 distinct field labels. A Search page that cannot find "squitter" — 46% of all
+decoded messages — has a real gap.
+
+#### Why the Index Is Compact Rather Than Full Text
+
+Almost all of that value is *classification* and *field presence*, not free text:
+
+| Design | at 11M messages | `squitter` | `temperature` |
+| ------ | --------------- | ---------- | ------------- |
+| **compact: variant description + field mask (adopted)** | **~28 MB** | 39,535 in 3.1 ms | 14,888 in 1.8 ms |
+| store decoded text | 464 MB | — | `LIKE` scan, ~66 ms, scales linearly |
+| store decoded text + FTS5 | 634 MB | fast | fast |
+
+The compact index delivers roughly **95% of the measured hits at ~9% of the FTS design's
+storage**. What it does not serve is exact *value* search — `35000` (2,305 hits) and `KDFW`
+(+329) — and those are format conversions of data already present in the raw text in another
+form.
+
+One case that looked like it would justify full text turned out not to: searchable fault text.
+The raw message already contains `CHECK APU FIRE LOOP B`, so that search works today. Decoding
+adds the *label* "Fault Log Report", not the content.
+
+#### Consequences for the Plan
+
+- **Phase 3** narrows to populating the index; it no longer persists decoded text.
+- **Phase 4 is removed.** No reprocessor, no cursor-driven decode diffing, no
+  `message_decode_updated` or `decoder_reprocess_progress` events, no `acars_decoder_*`
+  `system_config` keys. A decoder upgrade needs the *index* rebuilt, which is a ~92-second
+  backfill at measured decode speed — worth keeping the resumable-cursor pattern for, and
+  nothing else.
+- **The Search UI gains facets rather than only free text.** The 49 descriptions and 64 field
+  labels are small, closed, enumerable sets, so they belong in checkbox filters. That is better
+  than free text for this data: a user does not have to guess the word "squitter".
+- **Alert matching stays on raw text.** Decoded-aware alerting is a separate piece of work and
+  must not be done with substring matching — see below.
+
+#### Alert Matching Must Not Reuse This Naively
+
+Applying substring matching to decoded text actively degrades alerting. Measured against the
+station's real configured terms:
+
+| Term | apparent new matches | what actually matched |
+| ---- | -------------------- | --------------------- |
+| `PAN` | 3,071 | the field label "Com**pan**y Route" |
+| `RED` | 551 | the field label "Desi**red** Altitude" |
+
+`PAN` is a distress call; 3,071 false hits would make it useless. Matched against decoded
+*values* only, the same term set yields 549 genuine new matches across all 31 terms, and 545 of
+those are one static description string. So decoded-aware alerting needs word-boundary or
+value-only matching and is worth little — whereas decoded-aware *search* is worth a great deal.
+The two must not be conflated.

--- a/agent-docs/V4.3.md
+++ b/agent-docs/V4.3.md
@@ -518,10 +518,10 @@ cost stays negligible. Keep it cheap: a single write-path guard plus a prune-pat
 
 The new tables are split across **two** migrations, deliberately:
 
-| Migration | Tables                                                                  | Phase |
-| --------- | ----------------------------------------------------------------------- | ----- |
-| 16        | `aircraft`, `decoded_messages`, `system_config`, `messages.session_id`  | 1     |
-| 17        | `aircraft_positions`                                                    | 8     |
+| Migration | Tables                                                                                          | Phase |
+| --------- | ----------------------------------------------------------------------------------------------- | ----- |
+| 16        | `aircraft`, `decoder_variant`, `decoded_messages`, `system_config`, `messages.session_id`        | 1     |
+| 17        | `aircraft_positions`                                                                            | 8     |
 
 ### Why the Split
 
@@ -552,6 +552,38 @@ produce a broken revision chain that only fails at runtime, on a user's database
 `MIGRATIONS` array in `db/migrations/index.ts` is a serialization point: land migration work
 first, then fan out parallel tasks.
 
+### Migrations Under This Plan Are Mutable Until v4.3 Ships
+
+**Until v4.3 is released, the migrations it introduces may be edited in place.** If a shape
+turns out to be wrong, correct the migration itself — do **not** add a follow-up migration to
+undo it.
+
+This holds only because no released version has ever applied them, so no user database
+contains them. The only cost is that anyone running the `feat/v4.3` branch must discard their
+development database when a migration changes underneath them, which is acceptable for a
+development branch.
+
+The append-only, no-down-migration discipline described above resumes the moment v4.3 ships.
+Two consequences while the window is open:
+
+- Getting a shape slightly wrong is recoverable, so it is not necessary to defer a table
+  purely because one detail is unsettled.
+- It is still worth measuring first. Editing a migration is cheap; discovering after release
+  that a table is mis-shaped is not, and the window closes at the release, not at merge.
+
+### Branch Naming for v4.3 Task Branches
+
+Task branches use `feat/v4.3-phase-N-slug` and PR into `feat/v4.3`.
+
+The hyphen is not cosmetic. Git stores branches as paths under `refs/heads/`, so
+`refs/heads/feat/v4.3` (a file) and `refs/heads/feat/v4.3/phase-1-migration-16` (which needs
+`feat/v4.3` to be a directory) cannot coexist. Creating the latter fails with
+`cannot lock ref ... 'refs/heads/feat/v4.3' exists`. Any nested-slug scheme under a
+long-lived branch name hits this.
+
+Never rebase `feat/v4.3` — task branches are based on it. Merge `origin/main` into it when
+main moves, and run `just ci` after each integration merge.
+
 ### `aircraft` - Flight Session Registry
 
 Each row represents one flight session. Two appearances of the same aircraft are two rows.
@@ -575,17 +607,57 @@ CREATE TABLE aircraft (
     -- 'none' | 'pending' | 'live' | 'final' | 'unavailable' - see Trace Fetch Lifecycle
 );
 
-CREATE INDEX ix_aircraft_active_hex  ON aircraft(is_active, icao_hex);
-CREATE INDEX ix_aircraft_last_seen   ON aircraft(last_seen);
+CREATE INDEX ix_aircraft_active_hex ON aircraft(is_active, icao_hex);
 ```
 
-**Only two indexes.** The original plan specified five single-column indexes
-(`icao_hex`, `callsign`, `tail`, `is_active`, `last_seen`). The session matching query filters
-`is_active = 1` and then matches on identifiers, so a composite `(is_active, icao_hex)` serves
-the hot path; `last_seen` serves the expiry sweep. Callsign and tail lookups fall back to a
-scan of the active set, which is tens of rows, not millions. Adding indexes for them repeats
-the exact mistake migrations 13 and 15 were written to undo. Verify with
-`EXPLAIN QUERY PLAN` before adding any third index.
+`AUTOINCREMENT` is deliberate and load-bearing, not boilerplate. A plain `INTEGER PRIMARY KEY`
+reuses the rowids of deleted rows, so once Phase 6 prunes sessions a stale
+`messages.session_id` could silently re-point at a **different, newer** session — violating
+Architecture Invariant 5 (sessions are never retroactively re-assigned). `AUTOINCREMENT` makes
+a dangling reference stay dangling instead of becoming a wrong one. It costs one
+`sqlite_sequence` row.
+
+#### Exactly One Index, and Why the Second Was Dropped
+
+The original plan specified five single-column indexes, was narrowed to two
+(`(is_active, icao_hex)` plus `last_seen`), and is now **one**. Measured on real SQLite files,
+VACUUMed and `ANALYZE`d, at three cardinalities with the active set sized off arrival rate
+rather than retention depth:
+
+| rows (active) | no index | `(is_active, icao_hex)` | gain |
+| ------------- | -------- | ----------------------- | ---- |
+| 1,750 (36) | 0.0290 ms | 0.0074 ms | 3.9x |
+| 5,600 (109) | 0.0885 ms | 0.0074 ms | 12x |
+| 91,250 (52) | 1.4249 ms | 0.0080 ms | **178x** |
+
+`EXPLAIN QUERY PLAN` selects it with both columns:
+`SEARCH aircraft USING INDEX ix_aircraft_active_hex (is_active=? AND icao_hex=?)`.
+
+**`ix_aircraft_last_seen` was selected by zero of seven candidate queries, at every
+cardinality.** With both indexes present, every plan line names `ix_aircraft_active_hex`
+instead — including the expiry sweep it was supposedly added for. `is_active = 1` is roughly
+0.06% selective and `ANALYZE` knows it, so leading with `is_active` always beats leading with
+`last_seen`. It was dead index at 12.79 B/row.
+
+A composite `(is_active, last_seen)` replacement *is* selected for the sweep, but is not
+earned either: the sweep costs 1.43 ms at 91,250 rows and runs once every five minutes.
+
+| index set | B/row | index bytes as % of table |
+| --------- | ----- | ------------------------- |
+| one index (adopted) | 15.80 | 27.5% |
+| the plan's two | 28.59 | 49.8% |
+| all three identifiers indexed | 62.17 | 108.2% |
+
+Indexing `callsign` and `tail` as well makes the OR-form match query fast
+(`MULTI-INDEX OR`), but costs **more in index than the table itself** — the exact mistake
+migrations 13 and 15 were written to undo. Rejected.
+
+Cardinality note: `DB_SAVE_DAYS` defaults to 7 but is user-settable, and the shipped
+`docker-compose-testing-example.yaml` uses `1000`. `DB_ALERT_SAVE_DAYS` defaults to 120 and
+protects alert-matched messages from pruning. The high-cardinality column above is therefore a
+real configuration, not a stress test.
+
+Verify with `EXPLAIN QUERY PLAN` before adding any second index.
 
 ### Session Identifier Type
 
@@ -602,6 +674,34 @@ Sessions use the integer `aircraft.id`. Consequently:
   stays dropped forever. Phase 6 creates `ix_messages_session_id` on the new integer column
   once it is actually populated.
 
+The new column **does** carry a foreign key:
+
+```sql
+ALTER TABLE messages ADD COLUMN session_id INTEGER REFERENCES aircraft(id);
+```
+
+Verified against SQLite 3.53.4: this is accepted with no table rebuild (legal because the
+column is nullable and defaults to NULL), and defaults to `NO ACTION`, so a `DELETE` from
+`aircraft` that would orphan a message fails loudly. Deleting a *message* is never obstructed.
+
+`ON DELETE` is deliberately absent. `SET NULL` would let a buggy session prune silently discard
+message linkage, and the symptom — a history endpoint quietly returning an empty trail for a
+message that genuinely had one — is the plausible-looking kind of wrong this plan keeps warning
+about. **`ON DELETE CASCADE` must never appear on this column**: it would delete *messages* when
+a session is pruned.
+
+What the FK buys is narrow but real: it converts Phase 6's "only delete sessions with no
+surviving messages" from an application promise into a database guarantee. Note that
+`AUTOINCREMENT` on `aircraft.id` already prevents the worse failure (a reused rowid making a
+stale `session_id` point at a *different* session), so the FK is not carrying that load.
+
+Two operational notes. SQLite enforces a parent `DELETE` by scanning the child table, so
+`ix_messages_session_id` must exist before anything deletes from `aircraft`; Phase 6 creates it
+and is also the first phase to write the table, so the ordering is satisfied within one phase.
+And the failure mode under `NO ACTION` is bounded: `pruneDatabase()` deletes from `messages`
+first, so message pruning — the part that actually controls database size — completes before any
+session prune can fail.
+
 ### `aircraft_positions` - Trace-Sourced Position History
 
 **Deferred to migration 17, Phase 8.** See Position Schema above for the provisional DDL,
@@ -610,37 +710,164 @@ against the trace study report before migration 17 is written.
 
 ### `decoded_messages` - Decoded Text Storage
 
-Stores the output of `@airframes/acars-decoder` per message, along with the decoder version
-that produced it. This enables version-aware re-processing. See Decoder Re-processing below.
+Stores decoder output per message, along with which decoder produced it, so re-processing can
+find decodes made by a superseded version. See Decoder Re-processing below.
+
+Every figure in this section is measured against a production database
+(`messages_current.db`, 1.47 GB, 3,362,232 messages) using the real installed decoder
+(`@airframes/acars-decoder` 1.9.1), not a synthetic payload. **This table was the single
+largest storage risk in v4.3** and the plan as originally written would have made it larger
+than everything else in the release combined.
+
+#### Corpus Facts That Drive the Design
+
+| Fact | Value |
+| ---- | ----- |
+| Total messages | 3,362,232 |
+| Messages with non-empty `msg_text` | 1,286,979 (38.3%) |
+| Messages with no text at all | 2,075,253 (61.7%) |
+| Of text-bearing: decode to `full` | 21.7% |
+| Of text-bearing: decode to `partial` | 17.7% |
+| Of text-bearing: do not decode | 60.5% |
+| Text-bearing messages producing any output | 39.5% |
+| Distinct `(decoder_name, decoder_version)` pairs | 42 |
+
+So only **15.1% of all messages produce any decoded output at all**. Any design that puts a
+row on every message spends most of its bytes on placeholders.
+
+#### The Payload: What to Store
+
+`enrichment.ts:186-204` already reduces the decoder's `DecodeResult` to a small `DecodedText`
+before anything reaches the wire. The fields it discards — `raw` (~50 keys including nested
+route and wind arrays), `message` (an echo of the input, duplicating `messages.label` and
+`messages.msg_text`), `error`, and `decoder.type` — are read **nowhere** in the backend or
+frontend. "Store the decoder's output verbatim" was therefore never a real option; it would
+persist a large object the product does not consume.
+
+The frontend renders exactly three things: `decoder.decodeLevel`, and `formatted[].label` /
+`formatted[].value` (`MessageCard.tsx:397-417`, `decoderUtils.ts:32-57,283-293`).
+`decoder.name` is carried but never rendered — it is kept here for re-processing and
+diagnostics, not for the UI.
+
+Mean `decoded_json` length over rows that actually decode:
+
+| Encoding | Mean bytes |
+| -------- | ---------- |
+| Full `DecodeResult` (the strawman) | 915.6 |
+| `DecodedText` as built today | 412.2 |
+| `formatted` only, `{label, value}` objects | 344.8 |
+| `formatted` only, 2-tuples | **239.2** |
+
+The last step is free: `[["Description","..."],["Altitude","35000 ft"]]` carries the same
+information as `[{"label":"Description","value":"..."}]` without repeating the keys
+`"label"` and `"value"` on every item, which is a 42% cut against `DecodedText`. Because
+`decode_level` and the decoder identity are columns, keeping them inside `decoded_json` too
+would be pure duplication.
+
+#### Measured Shapes
+
+On-disk bytes, real corpus, VACUUMed, projected to 11M messages with a row on every message:
+
+| Shape | MB at 11M | vs baseline |
+| ----- | --------- | ----------- |
+| Plan as written, `decoded_json` = full `DecodeResult` | 2,933 | baseline |
+| Plan as written, `decoded_json` = `DecodedText` | 1,030 | -65% |
+| `formatted` objects | 904 | -69% |
+| `formatted` 2-tuples | 717 | -76% |
+| \+ variant lookup table | 640 | -78% |
+| \+ drop `decoded_at` | 586 | -80% |
+| \+ `decode_level` as INTEGER (**adopted**) | 542 | -82% |
+| \+ fold level into the variant key (rejected) | 530 | -82% |
+
+Folding `decode_level` into the variant key saves a further 12 MB (2%) but makes a per-message
+outcome part of a decoder-identity row and turns every level-filtered query into a join. Not
+worth it for 2%.
+
+`decoded_at` was dropped because nothing consumes it: the reprocessor keys on version, and
+sweep progress is tracked by `system_config.acars_decoder_reprocess_cursor`. It cost 54 MB at
+11M messages for record-keeping alone.
+
+#### Adopted Schema
 
 ```sql
-CREATE TABLE decoded_messages (
-    message_id      INTEGER PRIMARY KEY REFERENCES messages(id) ON DELETE CASCADE,
-    decoder_version TEXT    NOT NULL,
-    decode_level    TEXT    NOT NULL CHECK(decode_level IN ('full', 'partial', 'none')),
-    decoder_name    TEXT,
-    decoded_json    TEXT,   -- NULL when decode_level = 'none'
-    decoded_at      INTEGER NOT NULL
-) WITHOUT ROWID;
+CREATE TABLE decoder_variant (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    decoder_name    TEXT,               -- NULL when the message did not decode
+    decoder_version TEXT NOT NULL,
+    UNIQUE(decoder_name, decoder_version)
+);
 
-CREATE INDEX ix_decoded_version_level ON decoded_messages(decoder_version, decode_level);
+CREATE TABLE decoded_messages (
+    message_id   INTEGER PRIMARY KEY REFERENCES messages(id) ON DELETE CASCADE,
+    variant_id   INTEGER NOT NULL REFERENCES decoder_variant(id),
+    decode_level INTEGER NOT NULL CHECK(decode_level IN (0, 1, 2)),
+    decoded_json TEXT    -- NULL when decode_level = 0; otherwise a JSON array
+                         -- of [label, value] 2-tuples, rehydrated to
+                         -- DecodedTextItem[] on read
+) WITHOUT ROWID;
 ```
 
+`decode_level` is `0 = none`, `1 = partial`, `2 = full`. The integer encoding saves 44 MB at
+11M messages over the `TEXT` form and follows the precedent already set by `aircraft_positions`
+(`alt_25`, and its `-1` ground sentinel): integers with a documented mapping and a `CHECK`
+constraint, not human-readable strings on every row.
+
+The 42 observed `(decoder_name, decoder_version)` pairs occupy a **single 4 KB page**. Interning
+them removes ~19 B/row of repeated text from a table that is 1:1 with `messages`. Its `UNIQUE`
+constraint is the lookup path for upsert-on-insert; there is no separate index beside it, so no
+duplicate B-tree.
+
 Keyed on `messages.id`, not a UUID, for the same reason as sessions. The relationship is 1:1,
-so `message_id` is the primary key directly - no surrogate `id`, no separate unique index.
+so `message_id` is the primary key directly. Under `WITHOUT ROWID` that primary key **is** the
+table, which also means the `ON DELETE CASCADE` from `messages` needs no extra index.
 
-One composite index replaces the plan's two single-column indexes. The reprocessor's query is
-always "rows for a version other than the installed one, in decode-level priority order",
-which `(decoder_version, decode_level)` serves; neither column is independently selective
-enough to justify its own B-tree.
+#### Row Policy: Text-Bearing Messages Only
 
-Rows with `decode_level = 'none'` are stored intentionally. Without them, there is no way
-to distinguish "never tried" from "tried and could not decode" during re-processing sweeps.
+**Do not create a row for a message with empty `msg_text`.** No decoder version can ever decode
+a message with no text, so such a row would be a permanent placeholder that can never change.
+This saves 78 MB at 11M messages and makes the reprocessor's first pass meaningful:
 
-**Growth note**: this table is 1:1 with `messages`, which has a 7-day default retention, so
-it inherits that bound via `ON DELETE CASCADE`. But `decoded_json` is unbounded text and will
-be a material fraction of DB size. Store only what the frontend renders - do not persist the
-decoder's full internal output verbatim without measuring it first.
+| State | Meaning |
+| ----- | ------- |
+| No row, `msg_text` empty | Nothing to decode, ever. Not a re-processing candidate. |
+| No row, `msg_text` non-empty | Never processed. This is re-processing pass 1. |
+| Row present | Processed; `variant_id` says by which decoder and version. |
+
+This supersedes the original note that `decode_level = 'none'` rows exist to distinguish "never
+tried" from "tried and failed". That distinction is preserved — but only where it means
+something, which is text-bearing messages.
+
+With this policy the adopted shape costs **142 MB on the 3.36M-message production corpus** and
+roughly **464 MB at 11M messages**, against 896 MB and 2,933 MB respectively for the plan as
+originally written.
+
+#### No `ix_decoded_version_level`
+
+**Do not create it.** Measured at 1M rows it costs 19.66 B/row — **206 MB at 11M messages** —
+and buys nothing:
+
+| Query | Without index | With index |
+| ----- | ------------- | ---------- |
+| `WHERE decoder_version != ?` (as the plan describes the sweep) | 0.0262 ms `SCAN` | 0.0236 ms `SCAN USING COVERING INDEX` |
+| `WHERE decoder_version = ? AND decode_level = ?` | 0.0375 ms | 0.0343 ms |
+| Cursor sweep `WHERE message_id > ? ORDER BY message_id` | 0.0459 ms | 0.0470 ms, uses `PRIMARY KEY` |
+| Single-message retrieval JOIN | 0.0016 ms | 0.0023 ms, uses `PRIMARY KEY` |
+
+Three reasons it cannot pay: `!=` is not sargable so no seek is possible; after a version bump
+essentially every row matches, so a scan is already optimal; and the index is not selective —
+one installed version times three levels is **three distinct keys** over millions of rows. Both
+paths that matter (the cursor sweep and single-message retrieval) go via the primary key, which
+under `WITHOUT ROWID` is the table.
+
+The one shape that gains is ordering by decode-level priority (40.7 ms versus 71.1 ms), and
+both variants build a `TEMP B-TREE` at ~40 ms per 250-row batch, so Phase 4 must not use that
+shape regardless — it should run priority passes as separate cursor sweeps. Unlike a foreign
+key, `CREATE INDEX` needs no table rebuild, so this can be added later with evidence at no
+cost.
+
+**Growth note**: this table is 1:1 with `messages` and inherits its retention bound via
+`ON DELETE CASCADE`. At ~10% of database size it sits right on the Storage Discipline trigger
+threshold, which is why Open Question 7 exists.
 
 ### `system_config` - Persistent Key-Value Store
 
@@ -720,6 +947,16 @@ Matching priority is `icao_hex` > `callsign` > `tail`. If a session is found by 
 but the incoming data includes a new `icao_hex` not yet on that session, update the session
 row with the hex. This is "session enrichment" - identifiers accumulate over a session's life.
 
+**Step 1 must be issued as separate probes in priority order, not as one three-way `OR`.**
+This is measured, and the sole justification for `ix_aircraft_active_hex` depends on it. With
+`WHERE is_active = 1 AND (icao_hex = ? OR callsign = ? OR tail = ?)` the planner can only use
+the index's **leading column** — it degrades to `SEARCH ... (is_active=?)`, an index scan of
+the whole active set with the identifiers filtered in place. Probing
+`WHERE is_active = 1 AND icao_hex = ?` first gets the full two-column seek
+(`is_active=? AND icao_hex=?`), 0.0080 ms versus 1.4249 ms unindexed at 91,250 rows. Fall
+through to the callsign probe, then the tail probe, only when the previous one misses; those
+two are served by the leading-column restriction and need no index of their own.
+
 ### Session Expiry
 
 A background task (extending the existing scheduler in `services/background-services.ts`)
@@ -728,8 +965,18 @@ runs every 5 minutes and marks sessions inactive:
 ```sql
 UPDATE aircraft SET is_active = 0
 WHERE is_active = 1
-  AND last_seen < (now - TIMEOUT[session_type])
+  AND last_seen < (? - CASE session_type
+        WHEN 'adsb'  THEN 1200  WHEN 'vdlm2' THEN 2700
+        WHEN 'hfdl'  THEN 21600 WHEN 'adsc'  THEN 43200
+        ELSE 5400 END)
 ```
+
+**Use the single `CASE` statement, not one statement per `session_type`.** Measured, and it
+inverts the intuitive answer: the per-type form is sargable and the `CASE` form is not, yet
+`CASE` wins because five statements each traverse the active set while one traverses it once.
+At 91,250 rows with no index: 1.43 ms for `CASE` versus 7.24 ms for five per-type statements.
+The same direction holds in every index configuration tested. Sargability does not pay once
+the leading-column restriction has already narrowed the scan to a few dozen rows.
 
 Inactive sessions are retained in the database for historical queries. They are never deleted
 by the expiry process.
@@ -1149,21 +1396,33 @@ Phase numbering starts at 1. The original Phase 0 (documentation audit) is compl
 
 ### Phase 1: Database Migration 16
 
-Add `aircraft`, `decoded_messages`, and `system_config` tables, plus
-`messages.session_id INTEGER`. **Not** `aircraft_positions` — that is migration 17,
-Phase 8.
+Add `aircraft`, `decoder_variant`, `decoded_messages`, and `system_config` tables, plus
+`messages.session_id INTEGER REFERENCES aircraft(id)`. **Not** `aircraft_positions` — that is
+migration 17, Phase 8.
+
+All four table shapes are settled by measurement; see the per-table sections above for the
+adopted DDL and the evidence behind it. Phase 1 creates the storage only — Phase 3 fills
+`decoded_messages`, Phase 6 fills `aircraft`.
 
 **Deliverables**:
 
 - `db/migrations/migration16.ts` exporting `migration16_v43Tables`, registered in
   `db/migrations/index.ts`
-- Tests: fresh DB migration, idempotency (run twice), schema verification for all 3 tables,
-  `ON DELETE CASCADE` verified for `decoded_messages` -> `messages`
-- Test: `EXPECTED_INDEXES` in `db/__tests__/schema.test.ts` updated - it pins the index set
-  and will fail otherwise
+- Exactly one index across all four tables: `ix_aircraft_active_hex`. No
+  `ix_aircraft_last_seen`, no `ix_decoded_version_level` — both were measured and rejected.
+- Tests: fresh DB migration, idempotency (run twice), column/PK/type verification for all four
+  tables, `ON DELETE CASCADE` verified for `decoded_messages` -> `messages`
+- Test: `messages.session_id` foreign key is present and enforced — a `DELETE` from `aircraft`
+  with a referencing message fails, and deleting the message first then the session succeeds
+- Test: `decode_level` `CHECK` rejects values outside 0-2; `decoder_variant`'s `UNIQUE` is
+  enforced
+- Test: `EXPECTED_INDEXES` and `ALL_TABLES` in `db/__tests__/schema.test.ts` updated - they pin
+  the index and table sets and will fail otherwise
 - Test: confirm no index duplicates a primary key
-- Test: existing `pruneDatabase()` behaviour is unchanged by the first foreign key in the
-  schema (see Foreign Keys)
+- Test: existing `pruneDatabase()` behaviour is unchanged by the first foreign keys in the
+  schema (see Foreign Keys). Note prune deletes from `messages` before `alert_matches`, and
+  cascade fires only on a connection with `foreign_keys = ON` — which the migration connection
+  is not (`migrate.ts:223`).
 
 ### Phase 2: System Config Service
 
@@ -1431,8 +1690,9 @@ constraint from Storage Discipline, restated as hard checks.
 
 ## Open Questions
 
-Unresolved items. None blocks phases 1-6 or 10. Questions 1-2 block **Phase 8** and must be
-answered before migration 17 is written. Question 3 is already answered — see below.
+Unresolved items. Questions 1-2 block **Phase 8** and must be answered before the
+`aircraft_positions` migration is written. Question 7 blocks **Phases 3 and 4**. Question 3 is
+already answered — see below. Nothing here blocks Phases 1, 2, 5, 6 or 10.
 
 ### Data Collection In Progress
 
@@ -1475,3 +1735,55 @@ interpret the output.
 6. **Does `features_enabled` grow or get a sibling event?** It is typed as `Decoders`
    (`acarshub-types/src/system.ts:127-141`) and already carries non-decoder fields. Adding
    `ENABLE_POSITION_HISTORY` to it is precedented but semantically wrong.
+7. **Should decodes be persisted at all, or decoded on read?** (Blocks Phases 3 and 4.) See
+   below — this question was raised by measurement during Phase 1 and is not yet resolved.
+
+### Is Persisting Decodes Worth Its Storage?
+
+Measured on the production corpus with the real decoder, weighted over the actual mix of
+decode outcomes: **0.00836 ms per decode**. Counter-intuitively the messages that *fail* to
+decode are the slowest class (0.0111 ms), so a sample is not biased toward the flattering
+answer.
+
+Against that, the re-decode sites the plan cites as justification for persisting:
+
+| Site | Decodes | Cost |
+| ---- | ------- | ---- |
+| Ring-buffer warm-up at startup | 700 | 5.85 ms |
+| Search returning 50 results | 50 | 0.42 ms |
+| Search returning 500 results | 500 | 4.18 ms |
+| Alert term search, 200 results | 200 | 1.67 ms |
+
+So the performance case for `decoded_messages` is worth roughly **6 ms at startup and 4 ms on
+a large search**, in exchange for ~464 MB at 11M messages and ~10% database growth. On its own
+that is a poor trade, and Storage Discipline says to surface it rather than absorb it.
+
+The argument cuts deeper than storage. **Decode-on-read is always current by construction.** A
+retrieval path that decodes with the installed decoder can never return a stale decode, which
+means:
+
+- The staleness that Phase 4 exists to repair is *created* by Phase 3's persistence.
+- "A new version of `@airframes/acars-decoder` silently leaves old messages undecoded" — one of
+  the stated reasons v4.3 exists — is only true if decodes are persisted. Decode-on-read
+  upgrades all history the instant the package is bumped, for free.
+- Dropping persistence would remove the reprocessor, its cursor, all three
+  `acars_decoder_*` `system_config` keys, and the `message_decode_updated` and
+  `decoder_reprocess_progress` events.
+
+Arguments genuinely on the side of persisting, stated fairly:
+
+1. **SQL-queryable decoded text.** FTS over decoded output, or alert matching against decoded
+   rather than raw text, requires persistence. Nothing does this today (alert matching runs on
+   raw text in `insert.ts:244-399`) and it is not in Additional Features, but retrofitting it
+   later would need a backfill.
+2. **Regression protection.** If a decoder upgrade makes a decode *worse*, persistence keeps
+   the previous good output. Decode-on-read would lose it silently.
+3. **Target hardware.** The timings above were taken on a development machine, not on the
+   Pi-class hosts adsb.im deploys to. Even assuming 10x slower, startup warm-up is ~58 ms and
+   a 500-result search ~42 ms, which is still small — but this has not been measured on the
+   real target.
+
+Until this is resolved, `decoded_messages` and `decoder_variant` are specified above as
+measured, so that building them is cheap if the answer is "persist" and discarding them costs
+only a migration edit if it is not — see Migrations Under This Plan Are Mutable Until v4.3
+Ships.


### PR DESCRIPTION
v4.3 Phase 1. Creates `aircraft`, `decoder_variant`, `decoded_messages`, `system_config`, and adds `messages.session_id INTEGER REFERENCES aircraft(id)` — the schema's first foreign keys. Storage only; Phase 3 fills `decoded_messages`, Phase 6 fills `aircraft`.

Every shape here was settled by measurement against a production database rather than by following the plan as written. The plan changed as a result, and `agent-docs/V4.3.md` records the evidence so it is not re-derived later.

## Index evidence

Per the "no index without `EXPLAIN QUERY PLAN` evidence" rule. Measured on real SQLite files, VACUUMed and ANALYZEd, active set sized off arrival rate rather than retention depth.

Session-match hot path (runs per inbound message), hex probe:

| rows (active) | no index | `(is_active, icao_hex)` | gain |
| --- | --- | --- | --- |
| 1,750 (36) | 0.0290 ms | 0.0074 ms | 3.9x |
| 5,600 (109) | 0.0885 ms | 0.0074 ms | 12x |
| 91,250 (52) | 1.4249 ms | 0.0080 ms | **178x** |

```
SEARCH aircraft USING INDEX ix_aircraft_active_hex (is_active=? AND icao_hex=?)
```

**Two indexes the plan specified are NOT created**, both measured as dead weight:

- `ix_aircraft_last_seen` — selected by **zero of seven** candidate queries at every cardinality, including the expiry sweep it was added for. `is_active = 1` is ~0.06% selective and ANALYZE knows it, so leading with `is_active` always wins. 12.79 B/row for nothing.
- `ix_decoded_version_level` — 19.66 B/row, **206 MB at 11M rows**. `!=` cannot seek; after a version bump ~100% of rows match so a scan is already optimal; and it is three distinct keys over millions of rows. Both access paths that matter go via the primary key, which under `WITHOUT ROWID` *is* the table.

| query | without index | with index |
| --- | --- | --- |
| `WHERE decoder_version != ?` | 0.0262 ms `SCAN` | 0.0236 ms `SCAN USING COVERING INDEX` |
| cursor sweep `WHERE message_id > ?` | 0.0459 ms | 0.0470 ms, uses `PRIMARY KEY` |
| single-message retrieval JOIN | 0.0016 ms | 0.0023 ms, uses `PRIMARY KEY` |

Tests assert both are absent so they cannot be reintroduced without new measurement.

## Storage evidence

`decoded_messages` was the largest storage risk in v4.3. Sized against `messages_current.db` (3,362,232 messages) with the real decoder 1.9.1, not a synthetic payload. Projected to 11M messages:

| shape | MB at 11M |
| --- | --- |
| plan as written, `decoded_json` = full `DecodeResult` | 2,933 |
| `DecodedText` as the backend already builds it | 1,030 |
| `formatted` 2-tuples | 717 |
| \+ variant lookup table | 640 |
| \+ `decode_level` as INTEGER, no `decoded_at` (**adopted**) | 542 |

With the text-bearing-only row policy: **142 MB on the production corpus, ~464 MB at 11M** — an 84% reduction against the plan as written. Four independent findings drove it: the decoder's `raw`/`message`/`error` fields are read nowhere so "verbatim" was never an option; 2-tuple encoding drops repeated JSON keys; interning the 42 observed `(decoder_name, version)` pairs costs a single 4 KB page; and 61.7% of messages have no text at all so can never decode and need no row.

## A bug this caught

`decoder_name` was originally nullable. SQLite treats NULLs as **distinct** under `UNIQUE`, so that form permitted unlimited duplicate `(NULL, version)` rows and made the find-or-create lookup `WHERE decoder_name = ?` match nothing. Every non-decoding message — 60% of text-bearing traffic — would have minted a fresh variant row, defeating the interning the table exists for. Fixed with `NOT NULL DEFAULT ''`.

The first version of that regression test was **vacuous**: it inserted `''` twice, which collides under the broken schema too, so it passed either way. It now drives the path that was actually broken (omitted column, relying on the default) and has been verified to fail when the fix is reverted.

## Production validation

Migration run against a copy of a real database (never the original):

```
BEFORE: 3,362,232 messages, revision 8c9d47f5ed13
runMigrations() took 4.1s (includes VACUUM + ANALYZE on 1.4 GB)
AFTER revision: 4d2a7c918f3b
messages preserved: 3,362,232
session_id column count: 1     session_id all NULL: true
foreign_key_check: []          integrity_check: ok
```

The migration itself is sub-second; the 4.1s is almost entirely the pre-existing VACUUM.

## Other decisions

- **`messages.session_id` FK uses `NO ACTION`**, verified accepted via `ALTER TABLE` with no rebuild. `ON DELETE CASCADE` must never appear on this column — it would delete *messages* when a session is pruned. `SET NULL` was rejected because it turns a loud failure into a silent loss of linkage.
- **`AUTOINCREMENT` on `aircraft.id`** is load-bearing: rowid reuse would let a stale `session_id` point at a *different* session.
- **Shape-drift guard.** `CREATE TABLE IF NOT EXISTS` silently accepts a pre-existing table of the wrong shape. Since v4.3 migrations stay editable until release, a developer can hold a database built from an earlier draft; that would be stamped as migrated with the drift intact. Columns and nullability are now checked after creation and drift raises an actionable error.

## Review

Reviewed adversarially before merge; findings fixed in this branch: the vacuous regression test above, an idempotency test that never re-ran the migration (`runMigrations()` short-circuits on `alembic_version`, so it now calls the migration directly), the missing shape-drift guard, a fragile hardcoded prune count that broke its own file's convention, and two untested foreign-key enforcement directions.

`just ci` green. 1,351 backend tests pass, 27 of them new.
