### PR TITLE
chore(flake/precommit-base): `01acaa60` -> `9755ccd1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -101,11 +101,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784288435,
-        "narHash": "sha256-ReRHaLgr/uVqdD8afFSn+myXIfpHeOhP0yYe0TJqAA8=",
+        "lastModified": 1787424939,
+        "narHash": "sha256-O2tBn84NNuHrnqNVxx/XqsXwfYvS1YwBh+7CBnbCYsk=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "43b3c1ab9d40fb1dbb008f451988a91e375825e9",
+        "rev": "809414f0cdadf82cf11b06c2b29ba9b3168b3297",
         "type": "github"
       },
       "original": {
@@ -254,11 +254,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1785487287,
-        "narHash": "sha256-3eF2bngygCD5mfzUKbXWYFXRSCmHcPnEiHZdbeyGc4k=",
+        "lastModified": 1788068480,
+        "narHash": "sha256-tm9HODiIKc7bUOYbzJNgZmLJaOkF0YGJ1Z1XQnzKHs0=",
         "owner": "FredSystems",
         "repo": "pre-commit-checks",
-        "rev": "01acaa60808b41153970f9b0985ffb142b2ebfe5",
+        "rev": "9755ccd1fddcea517187bfd1d975d48bc42fe172",
         "type": "github"
       },
       "original": {
@@ -297,11 +297,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1785476452,
-        "narHash": "sha256-/CXwCFPS41rb/JI2VitKCgVK6V5E6/sfw5ke3B9zyVQ=",
+        "lastModified": 1787993548,
+        "narHash": "sha256-+IAEnmmx5YIhUWo0lp15jLLHchnXo5yKgWsi6C6Cf+0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "6ef009bf4c4873cdc1a621826722bdea7c03e62c",
+        "rev": "996e9b0b019a4a9eb9e9a5641aefa06d801b5895",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                         | Message                                               |
| -------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`9755ccd1`](https://github.com/fredsystems/pre-commit-checks/commit/9755ccd1fddcea517187bfd1d975d48bc42fe172) | `` chore(flake/nixpkgs): 9fbb54b3 -> 83199d0d ``      |
| [`769c644d`](https://github.com/fredsystems/pre-commit-checks/commit/769c644de8841a18f266222dca3959d5fc159004) | `` chore(flake/rust-overlay): 04ceec13 -> 996e9b0b `` |
| [`7c899ba7`](https://github.com/fredsystems/pre-commit-checks/commit/7c899ba722adaa37e5f4d6493a49b1f3e00ec508) | `` chore(flake/nixpkgs): ffb3c9b7 -> 9fbb54b3 ``      |
| [`7b40626d`](https://github.com/fredsystems/pre-commit-checks/commit/7b40626dc16338fc4ca7ac241893df912038b8f7) | `` chore(flake/rust-overlay): 89abdfd6 -> 04ceec13 `` |
| [`68246d51`](https://github.com/fredsystems/pre-commit-checks/commit/68246d514fb79a601679ec761f3be948248318f3) | `` chore(flake/git-hooks): 43b3c1ab -> 809414f0 ``    |
| [`58a5f530`](https://github.com/fredsystems/pre-commit-checks/commit/58a5f5309274af48b6611cafd506383a227d7d61) | `` chore(flake/rust-overlay): c84e121a -> 89abdfd6 `` |
| [`40049176`](https://github.com/fredsystems/pre-commit-checks/commit/40049176bd78e79a84322502e11770db8e042e1f) | `` chore(flake/nixpkgs): 0e251e24 -> ffb3c9b7 ``      |
| [`724249bf`](https://github.com/fredsystems/pre-commit-checks/commit/724249bfc4773b7a6640ec1fe78d324dd7ca965c) | `` chore(flake/rust-overlay): f1dcc7e4 -> c84e121a `` |
| [`42c10474`](https://github.com/fredsystems/pre-commit-checks/commit/42c10474772f46184668827c86ed97fc7fbd3fb3) | `` chore(flake/rust-overlay): 892c035d -> f1dcc7e4 `` |
| [`edd622fd`](https://github.com/fredsystems/pre-commit-checks/commit/edd622fddbac6968ee7185e28abb3a7b9bc289f1) | `` update flake inputs ``                             |
| [`a994d570`](https://github.com/fredsystems/pre-commit-checks/commit/a994d570247f1d80cbbcd8a33c4b4f866e16af87) | `` chore(flake/nixpkgs): 64380905 -> b7c2ada9 ``      |
| [`6d588ead`](https://github.com/fredsystems/pre-commit-checks/commit/6d588ead20bf977d4cc6fd499b8760e6f3ccd281) | `` chore(flake/rust-overlay): 29224977 -> 57a23bfa `` |
| [`01cf5823`](https://github.com/fredsystems/pre-commit-checks/commit/01cf5823724a9482eb716739e106354e62b14e01) | `` chore(flake/nixpkgs): e2587cae -> 64380905 ``      |
| [`73eaf96e`](https://github.com/fredsystems/pre-commit-checks/commit/73eaf96e4e293056878278c94ee6063362b282d9) | `` chore(flake/rust-overlay): 6ef009bf -> 29224977 `` |
| [`e9cf4ecf`](https://github.com/fredsystems/pre-commit-checks/commit/e9cf4ecff1f40ae5af7ef49d0db56699ba1a5b9e) | `` switch to tscgo ``                                 |
| [`0bd7d9c7`](https://github.com/fredsystems/pre-commit-checks/commit/0bd7d9c7cec4f68d8ef134ec48be0bac98f4c5fd) | `` switch to tscgo ``                                 |
| [`e211dcc4`](https://github.com/fredsystems/pre-commit-checks/commit/e211dcc41ca3e096a87df068c701423e5c1e5ab3) | `` switch to tscgo ``                                 |
| [`b89aae04`](https://github.com/fredsystems/pre-commit-checks/commit/b89aae04fa1bab38b15b5a2023571eb751cc9e85) | `` switch to tscgo ``                                 |
| [`35e756c3`](https://github.com/fredsystems/pre-commit-checks/commit/35e756c3e429fc8243706b640fc5d3b906e65d04) | `` switch to tscgo ``                                 |