### PR TITLE
chore(flake/npm-chck): `926b57a6` -> `860241a5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -71,7 +71,6 @@
     "git-hooks": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "gitignore": "gitignore",
         "nixpkgs": [
           "npm-chck",
           "precommit-base",
@@ -79,11 +78,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781733627,
-        "narHash": "sha256-U3yTuGBnmXvXoQI3qkpfEDsn9RovQPAjN7ndRco+3u0=",
+        "lastModified": 1787424939,
+        "narHash": "sha256-O2tBn84NNuHrnqNVxx/XqsXwfYvS1YwBh+7CBnbCYsk=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3bbec39bc90eadfa031e6f3b77272f3f60803e39",
+        "rev": "809414f0cdadf82cf11b06c2b29ba9b3168b3297",
         "type": "github"
       },
       "original": {
@@ -114,29 +113,6 @@
         "type": "github"
       }
     },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "npm-chck",
-          "precommit-base",
-          "git-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1785454630,
@@ -155,11 +131,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "lastModified": 1785454630,
+        "narHash": "sha256-LQy14TZp77TwbQf40gg1V3jo8FwJG0jGDkAH+zRHqg8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "rev": "1559d3daa3ecc813a650b79375ea61b6741b8746",
         "type": "github"
       },
       "original": {
@@ -207,11 +183,11 @@
         "precommit-base": "precommit-base"
       },
       "locked": {
-        "lastModified": 1783913686,
-        "narHash": "sha256-ir9YuGY1aoz+kFlrb9m3meOQfzO9wd8RoqOMUbqqlj8=",
+        "lastModified": 1788230683,
+        "narHash": "sha256-of3SfR02agUpiHGoH/uXMrGhXn8xo8r0DsrcC+bSuwU=",
         "owner": "FredSystems",
         "repo": "npm-chck",
-        "rev": "926b57a66293aa42699a5a430ee8bd3cbb299ce9",
+        "rev": "860241a5a6de8a140f0034e22dc040d62efbac7f",
         "type": "github"
       },
       "original": {
@@ -231,11 +207,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1782849529,
-        "narHash": "sha256-VqfO+f4MmXO6wKz3emHMlQwj1NkIxuFeZyYeIGgqX9U=",
+        "lastModified": 1788068480,
+        "narHash": "sha256-tm9HODiIKc7bUOYbzJNgZmLJaOkF0YGJ1Z1XQnzKHs0=",
         "owner": "FredSystems",
         "repo": "pre-commit-checks",
-        "rev": "6241f83dfeaae7a9c638d6981dcb1fd00a65f020",
+        "rev": "9755ccd1fddcea517187bfd1d975d48bc42fe172",
         "type": "github"
       },
       "original": {
@@ -279,11 +255,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1782789458,
-        "narHash": "sha256-CR55gKCChD9ffN1Ag5az20Z3RD4tylHlcM1SSohkMA8=",
+        "lastModified": 1787993548,
+        "narHash": "sha256-+IAEnmmx5YIhUWo0lp15jLLHchnXo5yKgWsi6C6Cf+0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "067959ef838c440558ca519cf08ca87f43c3db3a",
+        "rev": "996e9b0b019a4a9eb9e9a5641aefa06d801b5895",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                       |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`860241a5`](https://github.com/fredsystems/npm-chck/commit/860241a5a6de8a140f0034e22dc040d62efbac7f) | `` chore(flake/precommit-base): 01acaa60 -> 9755ccd1 ``                       |
| [`a794cf40`](https://github.com/fredsystems/npm-chck/commit/a794cf408880cbfcc4859a09c1287f54e878d7be) | `` fix(deps): update dependency inquirer to v14.2.0 (#64) ``                  |
| [`ca002c39`](https://github.com/fredsystems/npm-chck/commit/ca002c396170f24016f920eeb9fe3dd1dcb8c991) | `` chore(deps): update node.js to >=24.20.0 (#63) ``                          |
| [`d61ccdf9`](https://github.com/fredsystems/npm-chck/commit/d61ccdf9ac4f392b1afe3cb7fe6876b22246262c) | `` fix(deps): update dependency inquirer to v14.1.0 (#62) ``                  |
| [`935e67b0`](https://github.com/fredsystems/npm-chck/commit/935e67b0b193a707a643bcace763f76465cb7567) | `` fix(deps): update dependency globby to v16.2.4 (#61) ``                    |
| [`a277b667`](https://github.com/fredsystems/npm-chck/commit/a277b667290073892b3203859ade378662f1c694) | `` chore(deps): update dependency vitest to v4.1.11 (#60) ``                  |
| [`264d132a`](https://github.com/fredsystems/npm-chck/commit/264d132aa6a36483a34036b0555d5691d7040182) | `` chore(deps): update node.js to >=24.19.0 (#59) ``                          |
| [`a090ec54`](https://github.com/fredsystems/npm-chck/commit/a090ec547763cdaf26d6c88a56748cfdbd73cd48) | `` fix(deps): update dependency globby to v16.2.3 (#58) ``                    |
| [`c1b91b8e`](https://github.com/fredsystems/npm-chck/commit/c1b91b8ed326739c03cbc4186240cde5c55eba75) | `` docs: document workspace mode and range-style preservation ``              |
| [`6a1f26e8`](https://github.com/fredsystems/npm-chck/commit/6a1f26e8f79d37dbcaa188e1da260de79782e742) | `` fix(workspace): check every package in a monorepo, not just a bare root `` |
| [`35bf0991`](https://github.com/fredsystems/npm-chck/commit/35bf0991fd7aca3ac5cd174a9a6a3a84238f840b) | `` fix(workspace): preserve each dependency's existing range style ``         |
| [`9f80ed44`](https://github.com/fredsystems/npm-chck/commit/9f80ed44f91975c82313b1c761020ddfe89c3a94) | `` ci: don't fail the self-check when updates are available ``                |
| [`757407c0`](https://github.com/fredsystems/npm-chck/commit/757407c05dbee4e5b13f78fa10955d4d17b3029e) | `` chore(flake): sync npmDepsHash after dependency updates ``                 |
| [`6e0850ef`](https://github.com/fredsystems/npm-chck/commit/6e0850ef203b0d3948c01d8f79d500458fbe80da) | `` chore(deps): update dependency execa to v10.0.1 ``                         |
| [`82b1fd4f`](https://github.com/fredsystems/npm-chck/commit/82b1fd4fcf8f3de8bbb8dda4a5969ba2852d35dd) | `` chore(flake): sync npmDepsHash after dependency update ``                  |
| [`8fd303ba`](https://github.com/fredsystems/npm-chck/commit/8fd303ba57b25fba25a2045e456d1d5e65268693) | `` chore(flake): sync npmDepsHash after dependency update ``                  |
| [`ddfd7813`](https://github.com/fredsystems/npm-chck/commit/ddfd7813882ce1d435bacfc1ddbcaf3e3b3ca5f3) | `` chore(flake): sync npmDepsHash after dependency update ``                  |
| [`16d94342`](https://github.com/fredsystems/npm-chck/commit/16d94342ed2a05acaca545145817492af3e990de) | `` fix(deps): update dependency chalk to v6 ``                                |
| [`cf1a0ee0`](https://github.com/fredsystems/npm-chck/commit/cf1a0ee0f512ac5b3bf7826f063b4d061791a406) | `` fix(deps): update dependency minimatch to v10.2.6 ``                       |
| [`1f77459f`](https://github.com/fredsystems/npm-chck/commit/1f77459f69e9092aecef4bfca722828c7544a3bb) | `` chore(deps): update node.js to >=24.18.1 ``                                |
| [`1c89a62d`](https://github.com/fredsystems/npm-chck/commit/1c89a62d607dde3d129e208677e481d92091ce5d) | `` chore(flake/nixpkgs): b5aa0fbd -> 1559d3da ``                              |
| [`daf57768`](https://github.com/fredsystems/npm-chck/commit/daf57768baa9ea349fe86c60e129c57f84e5b1c4) | `` chore(flake/precommit-base): 6241f83d -> 01acaa60 ``                       |
| [`1e6ff4ff`](https://github.com/fredsystems/npm-chck/commit/1e6ff4ff93297f764a3ad81a017127384a60cf34) | `` chore(deps): update actions/checkout action to v7.0.1 ``                   |
| [`3aa22c1e`](https://github.com/fredsystems/npm-chck/commit/3aa22c1e85286ec7dc4433d84113dc617a144df4) | `` chore(flake): sync npmDepsHash after dependency update ``                  |
| [`b8d24e7f`](https://github.com/fredsystems/npm-chck/commit/b8d24e7fc0a1c7c9807f0ba4b587dd79d9c92e68) | `` chore(flake): sync npmDepsHash after dependency update ``                  |
| [`a16b14f3`](https://github.com/fredsystems/npm-chck/commit/a16b14f3bfffae21a312e820d5261f2f067feb7b) | `` chore(deps): lock file maintenance ``                                      |
| [`529df762`](https://github.com/fredsystems/npm-chck/commit/529df7625b123dd4d01b48460dc64127972d25e2) | `` chore(flake): sync npmDepsHash after dependency update ``                  |
| [`7d5e54c6`](https://github.com/fredsystems/npm-chck/commit/7d5e54c6b0597acd01d9f04a75f03bdcb1565000) | `` fix(deps): update dependency execa to v10 ``                               |
| [`907d55ce`](https://github.com/fredsystems/npm-chck/commit/907d55ce9f12c7ce8eb368ed018d2a123b302cbd) | `` chore(deps): update actions/setup-node action to v7 ``                     |
| [`fe6d30c4`](https://github.com/fredsystems/npm-chck/commit/fe6d30c4cd7bbfc0339b3f76b13bae6557ea2392) | `` chore(deps): update actions/setup-node action to v6.5.0 ``                 |
| [`7e7d6117`](https://github.com/fredsystems/npm-chck/commit/7e7d61177084f677143368bd8b301d12e6f2b41b) | `` fix(deps): update dependency globby to v16.2.2 ``                          |