### PR TITLE
chore(flake/nixpkgs): `1559d3da` -> `34ab9907`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -139,11 +139,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785454630,
-        "narHash": "sha256-LQy14TZp77TwbQf40gg1V3jo8FwJG0jGDkAH+zRHqg8=",
+        "lastModified": 1788179007,
+        "narHash": "sha256-hn1oU2rue2SYK8dAr8+WNZWtbsz1S2W5mnHlSEuh3bo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1559d3daa3ecc813a650b79375ea61b6741b8746",
+        "rev": "34ab99075ac4f7e40cf037eef32cb1c360bb85e9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                         |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
| [`04add32d`](https://github.com/NixOS/nixpkgs/commit/04add32d92d75593425f70210ea14c744c739e69) | `` python3Packages.svgpathtools: 1.7.2 -> 1.7.4 ``                                              |
| [`0b3cdfb7`](https://github.com/NixOS/nixpkgs/commit/0b3cdfb7af982f498ad2e817bd7af0d8a9063b32) | `` netbox: add missing tzdata dependency ``                                                     |
| [`5e24be15`](https://github.com/NixOS/nixpkgs/commit/5e24be15cb17706f6ed698bcf8f2f296e92a38e1) | `` netbox: add pkg test that base requirements are satisfied ``                                 |
| [`43560526`](https://github.com/NixOS/nixpkgs/commit/435605260bd13a41c42025f4c4d89fb1869d5008) | `` nixosTests.netbox: migrate to runTest ``                                                     |
| [`b68b2d0c`](https://github.com/NixOS/nixpkgs/commit/b68b2d0c730cdf05387b62d6106a9839c92d7af4) | `` nixos/netbox: fix typo in removed option ``                                                  |
| [`ff63d2ac`](https://github.com/NixOS/nixpkgs/commit/ff63d2ac5b6f25ffb2a5b47d839a9436ef37885b) | `` netbox_4_6: rename to netbox ``                                                              |
| [`8e556f8f`](https://github.com/NixOS/nixpkgs/commit/8e556f8fded1f8b4e7e231559d99895b54ff845d) | `` netbox_4_{4,5}: remove as EOL ``                                                             |
| [`21bd9cc8`](https://github.com/NixOS/nixpkgs/commit/21bd9cc86c7103e1578ecb457c36cbf5299fb082) | `` clojure: switch updater to nix-update-script ``                                              |
| [`7eca3ceb`](https://github.com/NixOS/nixpkgs/commit/7eca3ceb87869711566e6fc25732a67c5dac5af8) | `` texlive: fix mflua and luajittex on platforms without LuaJIT ``                              |
| [`53dab1e7`](https://github.com/NixOS/nixpkgs/commit/53dab1e7344e2466606fa5e8b56db5395085403e) | `` python3Packages.pepit: cleanup, skip failing tests ``                                        |
| [`98a3f410`](https://github.com/NixOS/nixpkgs/commit/98a3f410a7a6e079c69c28648839db20430482f7) | `` libretro.snes9x: 0-unstable-2026-08-17 -> 0-unstable-2026-08-27 ``                           |
| [`faca8b9c`](https://github.com/NixOS/nixpkgs/commit/faca8b9c19ea02b3d0896ba01eba5e20130cf489) | `` python3Packages.skops: skip failing test ``                                                  |
| [`6a7dbf2f`](https://github.com/NixOS/nixpkgs/commit/6a7dbf2f4a92347aead07ccd7afdcd99e4fc9aa0) | `` splash: 3.12.0 -> 4.0.0 ``                                                                   |
| [`5327526a`](https://github.com/NixOS/nixpkgs/commit/5327526a010e6cfe426270bc0cec036b41b50b65) | `` python3Packages.qutip: 5.2.3.post1 -> 5.3.1 ``                                               |
| [`f8dca5db`](https://github.com/NixOS/nixpkgs/commit/f8dca5db32622610a0e7a3403e50182193e3946d) | `` python3Packages.cvxpy: fix build ``                                                          |
| [`0c70e506`](https://github.com/NixOS/nixpkgs/commit/0c70e50604ccdb5aa348349afc99b483b10ec559) | `` python3Packages.qpsolvers: cleanup, skip failing tests ``                                    |
| [`d91a9aac`](https://github.com/NixOS/nixpkgs/commit/d91a9aac76a5d2409258c5c02195aa0846167e9a) | `` moji: 0.7.0 -> 0.8.0 ``                                                                      |
| [`adf6d015`](https://github.com/NixOS/nixpkgs/commit/adf6d015bab8dbc9587bf568aeb0fc163d2c8389) | `` harlequin: 2.12.0 -> 2.12.1 ``                                                               |
| [`36553f6e`](https://github.com/NixOS/nixpkgs/commit/36553f6ee17d6105b5206ea72942397a9372f8ed) | `` bulwark-plugins.pgp-true-end-to-end: fix license attribute ``                                |
| [`93db3aca`](https://github.com/NixOS/nixpkgs/commit/93db3aca12afe21f43bd6fe1d93b75b7157e93b2) | `` nixos/bulwark: always set TELEMETRY_DATA_DIR ``                                              |
| [`901f5b97`](https://github.com/NixOS/nixpkgs/commit/901f5b9792906772f8531002832bd52d3bb8f94e) | `` tailcat: init at 0.3.0 ``                                                                    |
| [`5a076737`](https://github.com/NixOS/nixpkgs/commit/5a07673751503207445e94321ffcc53200c6bf50) | `` prowler: 5.39.1 -> 5.40.0 ``                                                                 |
| [`7083d628`](https://github.com/NixOS/nixpkgs/commit/7083d6289569550c53e28e8b627441835b9a76a3) | `` llama-cpp: 0.2.0 -> 0.3.0 ``                                                                 |
| [`a8349ee1`](https://github.com/NixOS/nixpkgs/commit/a8349ee1611ebbd9d8be88072d1c197f310eb5dc) | `` llama-cpp: fetch the release tarball instead of a git clone ``                               |
| [`57672ec9`](https://github.com/NixOS/nixpkgs/commit/57672ec9d68b0f29bf2f1d202dfbace60e8531da) | `` llama-cpp: simplify the update script ``                                                     |
| [`59a08304`](https://github.com/NixOS/nixpkgs/commit/59a08304fff4de35774c5e857158d115340fbfa6) | `` llama-cpp: drop header copy already done by upstream cmake ``                                |
| [`0b84f7d2`](https://github.com/NixOS/nixpkgs/commit/0b84f7d25ee57311894ca9f05adc934403d87e3e) | `` python3Packages.stackit-ske: init at 1.13.0 ``                                               |
| [`2df6c85a`](https://github.com/NixOS/nixpkgs/commit/2df6c85a872f04d2714edff8a6f0aac6074570a7) | `` feishu-cli: 1.39.0 -> 1.40.0 ``                                                              |
| [`232735ac`](https://github.com/NixOS/nixpkgs/commit/232735ac1b2caa4ac432bd1936f456a8acc1060c) | `` bisq1: 1.10.5 -> 1.10.7 ``                                                                   |
| [`29e60e21`](https://github.com/NixOS/nixpkgs/commit/29e60e2178dfcb2da7d50c98d37a20e5c6cf04f4) | `` httpx: 1.10.0 -> 1.11.0 ``                                                                   |
| [`9b1b438a`](https://github.com/NixOS/nixpkgs/commit/9b1b438ad810acfe64132b5bee93924984a59bab) | `` scs: 3.2.11 -> 3.3.0 ``                                                                      |
| [`ff10ae4d`](https://github.com/NixOS/nixpkgs/commit/ff10ae4d748e86f141ce24cbfd903f635b896248) | `` bulwark-plugins: build source plugins, add store update script ``                            |
| [`d9da9140`](https://github.com/NixOS/nixpkgs/commit/d9da91405dd217fecb2be9f7079b40ac3237ae14) | `` cdncheck: 1.2.50 -> 1.2.51 ``                                                                |
| [`117cf998`](https://github.com/NixOS/nixpkgs/commit/117cf99877e0fc97c0529ee29981739179790137) | `` python3Packages.pytransportnswv2: 3.2.0 -> 3.3.3 ``                                          |
| [`88800ad8`](https://github.com/NixOS/nixpkgs/commit/88800ad88deeaff1be4b2e30fbafe4287028a0e0) | `` bottom: 0.14.8 -> 0.14.9 ``                                                                  |
| [`9fd9b12c`](https://github.com/NixOS/nixpkgs/commit/9fd9b12cdd47d4706ba875500831203e9eea1de9) | `` jrl-cmakemodules-scripts: add new check dependency ``                                        |
| [`9ddb56b8`](https://github.com/NixOS/nixpkgs/commit/9ddb56b83f7ed2d02f30dbf93e0f8f9d0f94f68d) | `` dnsx: 1.3.0 -> 1.3.1 ``                                                                      |
| [`965bebe6`](https://github.com/NixOS/nixpkgs/commit/965bebe6686d8f9a019db93d22167cbe028f7640) | `` python3Packages.publicsuffixlist: 1.0.2.20260821 -> 1.0.2.20260830 ``                        |
| [`b94a80ed`](https://github.com/NixOS/nixpkgs/commit/b94a80edcea4821039197bbed12a2e5f4bd3f2d3) | `` python3Packages.iamdata: 0.1.202608301 -> 0.1.202608311 ``                                   |
| [`3d75b68a`](https://github.com/NixOS/nixpkgs/commit/3d75b68ac520bf5bf06c26e04a90cbd53ade0b90) | `` python3Packages.iamdata: 0.1.202608291 -> 0.1.202608301 ``                                   |
| [`b57d7d26`](https://github.com/NixOS/nixpkgs/commit/b57d7d26de48b2dbd70d827e22e6b76b69bcea13) | `` qbz: 1.2.15 -> 2.0.2 ``                                                                      |
| [`57f4964f`](https://github.com/NixOS/nixpkgs/commit/57f4964f65707c629e6c1af769cdc7a4dbbcb06d) | `` maintainers: add vicrodh ``                                                                  |
| [`1928e23c`](https://github.com/NixOS/nixpkgs/commit/1928e23c21165a20a37a809509d1e51cebf5017b) | `` python3Packages.pyinstaller-hooks-contrib: 2026.6 -> 2026.7 ``                               |
| [`e253869b`](https://github.com/NixOS/nixpkgs/commit/e253869b32a91b18d3d05651bb4635a718e3ebb1) | `` beamPackages.mixRelease: add bash to buildInputs ``                                          |
| [`f0dd73c2`](https://github.com/NixOS/nixpkgs/commit/f0dd73c2700640ee9f3c0e9a1c2ad4b4e4856e07) | `` gamescope: 3.16.25 -> 3.16.28 ``                                                             |
| [`09e963b3`](https://github.com/NixOS/nixpkgs/commit/09e963b321e501fde07970c683a0965a29c9641a) | `` zed-editor: 1.16.1 -> 1.17.2 ``                                                              |
| [`2554bf74`](https://github.com/NixOS/nixpkgs/commit/2554bf74e927d92284cc069396151eec53f08c91) | `` fabric-ai: 1.4.470 -> 1.4.473 ``                                                             |
| [`a492ef1c`](https://github.com/NixOS/nixpkgs/commit/a492ef1cdd7bbbe5274ebfd2be49415207daecd1) | `` tether: 0.2.18 -> 0.2.19 ``                                                                  |
| [`017ba544`](https://github.com/NixOS/nixpkgs/commit/017ba5441a2ce055d752d3575b223f012eb7d75d) | `` beekeeper-studio: 6.0.4 -> 6.0.5 ``                                                          |
| [`69749a59`](https://github.com/NixOS/nixpkgs/commit/69749a59a654a90f01a432c62ce5295365ee9be0) | `` visidata: 3.3 -> 3.4 ``                                                                      |
| [`318d4e09`](https://github.com/NixOS/nixpkgs/commit/318d4e091d45185a2f56353731e9a7b14e216aaa) | `` home-assistant-custom-lovelace-modules.hourly-weather: 6.9.0 -> 7.0.0 ``                     |
| [`129b5f2c`](https://github.com/NixOS/nixpkgs/commit/129b5f2c273c9d8cf3119e3b3abc60c5ad5a9c88) | `` iptvnator: 0.22.0 -> 0.23.0 ``                                                               |
| [`519b3f18`](https://github.com/NixOS/nixpkgs/commit/519b3f1881f3c75910c6ff42540332ac0ce75099) | `` fairywren: 0-unstable-2026-08-21 -> 0-unstable-2026-08-24 ``                                 |
| [`640e6118`](https://github.com/NixOS/nixpkgs/commit/640e6118ae32690e67bd675925dcf73f3a91adb0) | `` gotify-server: 3.0.0 -> 3.1.0 ``                                                             |
| [`31721c08`](https://github.com/NixOS/nixpkgs/commit/31721c0824c75af0c4df199a6d79a78322a66a80) | `` python3Packages.oelint-data: 1.5.16 -> 1.5.18 ``                                             |
| [`719ea968`](https://github.com/NixOS/nixpkgs/commit/719ea96854e47d80133c6603bc55e89b5ef378aa) | `` vencord: 1.15.3 -> 1.15.4 ``                                                                 |
| [`7cd6fa14`](https://github.com/NixOS/nixpkgs/commit/7cd6fa1480ce75c30312d21d0604e75bc59a587d) | `` python3Packages.lancedb: 0.36.0 -> 0.37.1 ``                                                 |
| [`ece4ea3c`](https://github.com/NixOS/nixpkgs/commit/ece4ea3c0ca9a6c552a8de41a07165b732e8db78) | `` gradle_7: drop ``                                                                            |
| [`80cb00e3`](https://github.com/NixOS/nixpkgs/commit/80cb00e37c7b7d42a00c20293a523af9d4c422fb) | `` aide: 0.19.3 -> 0.19.4 ``                                                                    |
| [`90a8eeea`](https://github.com/NixOS/nixpkgs/commit/90a8eeea3cb73983a1e34e1c4984ff068ffe0dd0) | `` uzdoom: fix ALSA device support ``                                                           |
| [`4e1f5821`](https://github.com/NixOS/nixpkgs/commit/4e1f58216ec9ae52312bf36ca17ff51a4e95d023) | `` python3Packages.pylance: 10.0.0 -> 11.0.0 ``                                                 |
| [`1d970958`](https://github.com/NixOS/nixpkgs/commit/1d9709587ac319399b17c8f94412c9ae26ca101d) | `` python3Packages.lance-namespace: 0.9.0 -> 0.11.1 ``                                          |
| [`7e75ffa2`](https://github.com/NixOS/nixpkgs/commit/7e75ffa2a59bf3f729196cbc629c3ca07368184b) | `` python3Packages.lance-namespace-urllib3-client: 0.9.0 -> 0.11.1 ``                           |
| [`467c03cb`](https://github.com/NixOS/nixpkgs/commit/467c03cbe2f4548ed770fa36aff8427594c46e78) | `` radicle-artifact: init at 0.18.0 ``                                                          |
| [`f11d8448`](https://github.com/NixOS/nixpkgs/commit/f11d844894b1e9196ed8f3d9d68adcc5db11bf0e) | `` gitbeaker-cli: trim install size significantly ``                                            |
| [`8df4de7e`](https://github.com/NixOS/nixpkgs/commit/8df4de7e8ec33956375a6d3239514a667688d641) | `` fleet: 4.82.2 -> 4.90.1 ``                                                                   |
| [`6da62a01`](https://github.com/NixOS/nixpkgs/commit/6da62a01540923c8ebe00853a0e88be50f71729b) | `` ddhx: 0.11.0 -> 0.12.0 ``                                                                    |
| [`20d7fdfc`](https://github.com/NixOS/nixpkgs/commit/20d7fdfc42a341883dacf359ea765fe66c4e7f5e) | `` fuse-overlayfs: 1.17 -> 1.18 ``                                                              |
| [`c3d70544`](https://github.com/NixOS/nixpkgs/commit/c3d7054464866cff1ae39b8a183d850a8d765505) | `` python3Packages.spacy: skip failing test on python 3.14 ``                                   |
| [`f5d95d77`](https://github.com/NixOS/nixpkgs/commit/f5d95d7705a052ae0e096ce2b06a539f77248de3) | `` python3Packages.python-crontab: 3.3.0 -> 3.4.0 ``                                            |
| [`ce3bdff8`](https://github.com/NixOS/nixpkgs/commit/ce3bdff8b96b1f559e1815688eac168477d22cd9) | `` python3Packages.wandb: 0.28.2 -> 0.29.0 ``                                                   |
| [`b9e9cc64`](https://github.com/NixOS/nixpkgs/commit/b9e9cc6473c9bdd519264c96bfe4c85ab2b535aa) | `` python3Packages.cwsandbox: 0.23.0 -> 1.7.0 ``                                                |
| [`3fdff0dc`](https://github.com/NixOS/nixpkgs/commit/3fdff0dcd62c727849281a128c27f6f2ac5ded2e) | `` python3Packages.validate-pyproject-schema-store: 2026.08.15 -> 2026.08.29 ``                 |
| [`59785619`](https://github.com/NixOS/nixpkgs/commit/5978561946f5b09808c427fa439868bb313a8f2e) | `` tgpt: 2.13.0 -> 2.14.0 ``                                                                    |
| [`478a6e2f`](https://github.com/NixOS/nixpkgs/commit/478a6e2f16c4c66a09926ad1535c181034f373ad) | `` python3Packages.pyexploitdb: 0.3.41 -> 0.3.42 ``                                             |
| [`557095d7`](https://github.com/NixOS/nixpkgs/commit/557095d700e22c88b5667ca3ab321e6403fd1049) | `` libretro: move to pkgs/by-name ``                                                            |
| [`d6d30fa4`](https://github.com/NixOS/nixpkgs/commit/d6d30fa462615dfbc6ba21033cb7aa2b38b3544c) | `` h: modernize ``                                                                              |
| [`d89f5d5c`](https://github.com/NixOS/nixpkgs/commit/d89f5d5c39ef90b43236a4433f8d602e2735d4d8) | `` python3Packages.spacy: 3.8.14 -> 3.8.16 ``                                                   |
| [`673abef2`](https://github.com/NixOS/nixpkgs/commit/673abef2171bc11bd2a03c084b6f000722bf5265) | `` budget-tracker-tui: 1.4.1 -> 1.4.2 ``                                                        |
| [`215e0e5b`](https://github.com/NixOS/nixpkgs/commit/215e0e5b7a66f3ce8feab7fcb56c4a7aded0debc) | `` fcitx5-areca: update meta.description ``                                                     |
| [`d850042e`](https://github.com/NixOS/nixpkgs/commit/d850042e258f910374d783fabd451501af7db21f) | `` home-assistant-custom-components.mitsubishi: 0.5.7 -> 0.6.0 ``                               |
| [`b35b967e`](https://github.com/NixOS/nixpkgs/commit/b35b967ed997caae1de5a49ac3834d32382c76bd) | `` protonplus: 0.5.21 -> 0.6.5 ``                                                               |
| [`1252c162`](https://github.com/NixOS/nixpkgs/commit/1252c1627aa675218f9dee74b5734d2dbc64d70b) | `` python3Packages.mhcgnomes: 3.33.5 -> 3.39.0 ``                                               |
| [`385d1098`](https://github.com/NixOS/nixpkgs/commit/385d109882b46c8e9c9774d07869a2e8e938e31d) | `` libretro.tgbdual: 0-unstable-2026-05-11 -> 0-unstable-2026-08-23 ``                          |
| [`3cc227b8`](https://github.com/NixOS/nixpkgs/commit/3cc227b8b26d5fabb71d024844cc7a4f8b2803b0) | `` liteparse: 2.13.0 -> 2.14.2 ``                                                               |
| [`b628736c`](https://github.com/NixOS/nixpkgs/commit/b628736cd734ef8856aeef60268223055ec913ef) | `` libretro.nestopia: 0-unstable-2026-07-29 -> 0-unstable-2026-08-30 ``                         |
| [`4062fbbe`](https://github.com/NixOS/nixpkgs/commit/4062fbbeeceaee5ceaf7f53212d5597c86896bf3) | `` resterm: 1.2.4 -> 1.5.0 ``                                                                   |
| [`a3fd032c`](https://github.com/NixOS/nixpkgs/commit/a3fd032cd40c82e9b41bee9eaf9cdc8d17d0bb07) | `` euphonica: add extra gdk pixbuf cache loaders ``                                             |
| [`7d6dabf7`](https://github.com/NixOS/nixpkgs/commit/7d6dabf78e8fb4fc26152190182fa4ce82cc2fd0) | `` gitlab-ci-local: 4.74.0 -> 4.75.1 ``                                                         |
| [`ced298ce`](https://github.com/NixOS/nixpkgs/commit/ced298cee5e29b7b63cc8baca8cd0da2bfbbe230) | `` tpsecore: set updateScript ``                                                                |
| [`6bc192f2`](https://github.com/NixOS/nixpkgs/commit/6bc192f2998c64b83fef34a5f640dd9b6e679d9f) | `` tpsecore: use writableTmpDirAsHomeHook ``                                                    |
| [`ebbaf3eb`](https://github.com/NixOS/nixpkgs/commit/ebbaf3eb4f3068050de3e5d62ddd44bc5afcb79c) | `` tetrio-plus: update tpsecore wasm filename ``                                                |
| [`af7768d3`](https://github.com/NixOS/nixpkgs/commit/af7768d3fe35e4f2288f8677d137b785d08fe023) | `` tpsecore: 0.1.1 -> 0.1.1-unstable-2026-04-06 ``                                              |
| [`0bd39e73`](https://github.com/NixOS/nixpkgs/commit/0bd39e73d6d87394fc2dacd5a867563b842c81be) | `` libretro.beetle-pcfx: 0-unstable-2026-04-22 -> 0-unstable-2026-08-23 ``                      |
| [`e9bd7b2a`](https://github.com/NixOS/nixpkgs/commit/e9bd7b2a8dc9ba18ec304c634fe135001d4070db) | `` python3Packages.pyimouapi: 1.3.5 -> 1.4.0 ``                                                 |
| [`57a152b6`](https://github.com/NixOS/nixpkgs/commit/57a152b6bcf57ccf8918790ace1ac28a949acf63) | `` automatic-timezoned: 2.0.156 -> 2.0.158 ``                                                   |
| [`cb3ec1a7`](https://github.com/NixOS/nixpkgs/commit/cb3ec1a7e2548ca1869f47feb13eaaa170c91837) | `` libretro.neocd: 0-unstable-2026-04-20 -> 0-unstable-2026-08-30 ``                            |
| [`5e550c62`](https://github.com/NixOS/nixpkgs/commit/5e550c626300ec723c1d0087e5042ae36a57b0e2) | `` unciv: 4.21.9 -> 4.21.14 ``                                                                  |
| [`01b4df93`](https://github.com/NixOS/nixpkgs/commit/01b4df93b957d6dac71a37806fff59b82a30313d) | `` stalwart_0_16: 0.16.19 -> 0.16.20 ``                                                         |
| [`413bc0c0`](https://github.com/NixOS/nixpkgs/commit/413bc0c042835439048e2eb9b317d5ffb8379153) | `` libretro.dolphin: 0-unstable-2026-08-19 -> 0-unstable-2026-08-27 ``                          |
| [`642e3700`](https://github.com/NixOS/nixpkgs/commit/642e370015234bbe1cd1fd5628b0a0912a3b17fc) | `` nixosTests.kapla: init ``                                                                    |
| [`c0e2933c`](https://github.com/NixOS/nixpkgs/commit/c0e2933ca5fdb659c8cae6dd7bebc0a89e7271d6) | `` nixos/kapla: init ``                                                                         |
| [`b3f5352c`](https://github.com/NixOS/nixpkgs/commit/b3f5352c7c6035a41eeb055070f65cac9010cba9) | `` ocamlPackages.kapla: init at 0.4.0 ``                                                        |
| [`dd5f7064`](https://github.com/NixOS/nixpkgs/commit/dd5f7064840b67fb2238e6c113a90aa8a7a67e86) | `` ocamlPackages.eris: init at 1.0.0-unstable-2026-03-11 ``                                     |
| [`996eb688`](https://github.com/NixOS/nixpkgs/commit/996eb68819618c28bb3ee728b5974ce8647ecff9) | `` ocamlPackages.monocypher: init at 0.3.0 ``                                                   |
| [`0dd13a22`](https://github.com/NixOS/nixpkgs/commit/0dd13a220385781b2c50ef8a88735923835fcf1a) | `` ocamlPackages.cborl: init at 0.1.0 ``                                                        |
| [`960f7afb`](https://github.com/NixOS/nixpkgs/commit/960f7afba87400a5012af65626c54b84a6c4f38e) | `` ocamlPackages.base32: init at 1.0.0 ``                                                       |
| [`b7b59f39`](https://github.com/NixOS/nixpkgs/commit/b7b59f39af4d3b2d76667266520ad56846f24bea) | `` cudatext: 1.236.0.4 -> 1.236.0.5 ``                                                          |
| [`75acf72a`](https://github.com/NixOS/nixpkgs/commit/75acf72a3d7a0b3a97c0823d8b07686f6facd758) | `` tideways-daemon: 1.18.2 -> 1.18.6 ``                                                         |
| [`b8fcd3ef`](https://github.com/NixOS/nixpkgs/commit/b8fcd3efbfc5f1d431cdd906d5e07d23b0688a2c) | `` terraform-providers.spacelift-io_spacelift: 1.53.5 -> 1.54.0 ``                              |
| [`c40be2b8`](https://github.com/NixOS/nixpkgs/commit/c40be2b8ad363165d4cef91c8182deec18ab6b3d) | `` buildNeovimPlugin: fix doubled version string ``                                             |
| [`571e09c7`](https://github.com/NixOS/nixpkgs/commit/571e09c74b187b2b02ba7887d87336143baa6991) | `` glab-tui: 0.8.4 -> 0.9.0 ``                                                                  |
| [`eb9d3a09`](https://github.com/NixOS/nixpkgs/commit/eb9d3a094eb02b57b5c98ad52a97936830eccf0b) | `` python3Packages.pyportainer: 1.0.44 -> 1.0.45 ``                                             |
| [`46394210`](https://github.com/NixOS/nixpkgs/commit/463942109d390b06781b5a1a34510710eb5db815) | `` rtrtr: add stepbrobd to maintainer ``                                                        |
| [`95914c63`](https://github.com/NixOS/nixpkgs/commit/95914c639538ffe60649d91a3a52d9011acd9edb) | `` maintainers: remove steamwalker ``                                                           |
| [`01c5fee6`](https://github.com/NixOS/nixpkgs/commit/01c5fee632096f88259d526e2e88a32ae8d16666) | `` gnucap-modelgen-verilog: 20240220 -> 20260729-dev ``                                         |
| [`c4436bfa`](https://github.com/NixOS/nixpkgs/commit/c4436bfa80cf9334bf7ba19ff79170181d5dee6f) | `` everest: 6458 -> 6485 ``                                                                     |
| [`1cd1b69f`](https://github.com/NixOS/nixpkgs/commit/1cd1b69fb4721079b6d7ede6e78e9beda583a48c) | `` mistral-vibe: 2.24.3 -> 2.24.5 ``                                                            |
| [`948b7eb9`](https://github.com/NixOS/nixpkgs/commit/948b7eb9b5b61d3398f5f15d007ee166e9630754) | `` python3Packages.mistralai: 2.9.1 -> 2.9.4 ``                                                 |
| [`d6f7d55a`](https://github.com/NixOS/nixpkgs/commit/d6f7d55a02faba40854e271407fd52a224dd9b76) | `` stackwhere: init at 0.3.2 ``                                                                 |
| [`c3a6201c`](https://github.com/NixOS/nixpkgs/commit/c3a6201c58a1e2c9e1e684a66db0bb74209559b2) | `` tree-sitter-grammars.tree-sitter-rocq: init at 0.2.0 ``                                      |
| [`adcbe72d`](https://github.com/NixOS/nixpkgs/commit/adcbe72d496ef84ff77bda6d84466b0cb2867355) | `` stamp: 0-unstable-2026-07-13 -> 0-unstable-2026-08-24 ``                                     |
| [`9f23758d`](https://github.com/NixOS/nixpkgs/commit/9f23758d51c664d6be797fd2b41d7523b0d6dce0) | `` terraform-providers.aliyun_alicloud: 1.289.0 -> 1.290.0 ``                                   |
| [`9909206e`](https://github.com/NixOS/nixpkgs/commit/9909206e20c7d3f66941c68ac6f66796fde718a2) | `` bpfvet: init at 0.2.1 ``                                                                     |
| [`19383a27`](https://github.com/NixOS/nixpkgs/commit/19383a27c6ae0adeece7ae832957b4cb1185f702) | `` tether: init at 0.2.18 ``                                                                    |
| [`2c567fb9`](https://github.com/NixOS/nixpkgs/commit/2c567fb9685d9058595ba0b7e506addcdf26da55) | `` nextcloudPackages: update apps 2026-08-30 ``                                                 |
| [`fe88a785`](https://github.com/NixOS/nixpkgs/commit/fe88a7856d0fa76910124b6d682d794a6a73bb28) | `` tgpt: 2.13.0 -> 2.14.0 ``                                                                    |
| [`2fd86ff4`](https://github.com/NixOS/nixpkgs/commit/2fd86ff4546c9e3f82afafc32edff696094b4727) | `` lasuite-docs: 5.4.1 -> 5.5.0 ``                                                              |
| [`e42a83c8`](https://github.com/NixOS/nixpkgs/commit/e42a83c85b9ad84d8f4a31d3f05018cbbd259757) | `` niks3: 1.10.0 -> 1.10.1 ``                                                                   |
| [`4f384b55`](https://github.com/NixOS/nixpkgs/commit/4f384b55dc6b72a375c2d471d3016319bac5710d) | `` python3Packages.timm: 1.0.28 -> 1.0.29 ``                                                    |
| [`1db2471c`](https://github.com/NixOS/nixpkgs/commit/1db2471c338a448cdda7c256d96c40f9c7cfebf3) | `` python3Packages.jupyter-themes: change pname to jupyterthemes to fix metadata check ``       |
| [`e8ba8673`](https://github.com/NixOS/nixpkgs/commit/e8ba8673962b3f54f39b7dc62509986262dec391) | `` python3Packages.jupyter-themes: cleanup ``                                                   |
| [`aacb49db`](https://github.com/NixOS/nixpkgs/commit/aacb49dbb4ec052665d36a0d0a60e41a87ab57b8) | `` python3Packages.defusedcsv: use finalAttrs and enable __structuredAttrs ``                   |
| [`aaaf5424`](https://github.com/NixOS/nixpkgs/commit/aaaf5424b5596b1c3a7898cd65b941723da605cf) | `` pretalx.plugins.youtube: 2.6.0 -> 3.0.0 ``                                                   |
| [`8f313497`](https://github.com/NixOS/nixpkgs/commit/8f3134976fdc279ef31b7eaca37588a99dafbec5) | `` pretalx.plugins.vimeo: 2.7.0 -> 2.8.0 ``                                                     |
| [`fb8cb797`](https://github.com/NixOS/nixpkgs/commit/fb8cb79724ea90d34329de2210bcb3fcd9e34883) | `` pretalx.plugins.venueless: 1.8.0 -> 1.9.0 ``                                                 |
| [`b06ca012`](https://github.com/NixOS/nixpkgs/commit/b06ca012581f84c7ef5fdeccd0006026195efffb) | `` pretalx.plugins.public-voting: 1.10.0 -> 1.11.0 ``                                           |
| [`34b682b4`](https://github.com/NixOS/nixpkgs/commit/34b682b4301b2acc5fd9aba85f0d78797aaccbbc) | `` pretalx.plugins.pages: 1.9.0 -> 1.10.0 ``                                                    |
| [`85875c1b`](https://github.com/NixOS/nixpkgs/commit/85875c1b4a1b3a42931c9d038e5fbc06213a5025) | `` pretalx.plugins.media-ccc-de: 1.7.0 -> 1.8.0 ``                                              |
| [`4bd478db`](https://github.com/NixOS/nixpkgs/commit/4bd478db77a78bb59aae5599e4108e668c4885aa) | `` pretalx.plugins.downstream: 1.5.0 -> 1.6.0 ``                                                |
| [`26dc790b`](https://github.com/NixOS/nixpkgs/commit/26dc790becb8dffee626d863efbba2a93f5d9d43) | `` python3Packages.otter-grader: 6.1.6 -> 7.0.0 ``                                              |
| [`d36843f2`](https://github.com/NixOS/nixpkgs/commit/d36843f2f6ac234930afe63e6300c2020bbbdec6) | `` python3Packages.spatialmath-python: modernize ``                                             |
| [`8e40a659`](https://github.com/NixOS/nixpkgs/commit/8e40a659fe9e6b9ec248996b0d3aea4e07d41153) | `` python3Packages.python-frontmatter: 1.1.0 -> 1.3.0 ``                                        |
| [`05b9c6b0`](https://github.com/NixOS/nixpkgs/commit/05b9c6b0a34e91900055d4e1db5d474084174e5f) | `` python3Packages.moyopy: 0.15.0 -> 0.17.0 ``                                                  |
| [`5adc3fe0`](https://github.com/NixOS/nixpkgs/commit/5adc3fe0152193b55edb681f4f81001a6cb4ceb8) | `` qbom: 0.1.0-unstable-2026-01-21 -> 0.1.1 ``                                                  |
| [`732d391f`](https://github.com/NixOS/nixpkgs/commit/732d391f2226d585e85474623d26f691549a05c4) | `` python3Packages.bytecode: 0.18.1 -> 0.19.0 ``                                                |
| [`de70f5ad`](https://github.com/NixOS/nixpkgs/commit/de70f5ad0d4e19e8350630cbbbe211b02c7cf36a) | `` stave: init at 0.0.3 ``                                                                      |
| [`87c74c8c`](https://github.com/NixOS/nixpkgs/commit/87c74c8c091435b7ef3b1838bbb3a98529d714a2) | `` fff-mcp: init at 0.10.6 ``                                                                   |
| [`3bd7640e`](https://github.com/NixOS/nixpkgs/commit/3bd7640e93a629e72207c4292a0fd1a836ddd57a) | `` spicedb: 1.54.0 -> 1.56.1 ``                                                                 |
| [`038eb058`](https://github.com/NixOS/nixpkgs/commit/038eb0581ab4aba7a1677a384c680e6721cca651) | `` dutctl: 1.0.0-alpha.1-unstable-2026-08-06 -> 1.0.0-alpha.2-unstable-2026-08-25 ``            |
| [`8432892f`](https://github.com/NixOS/nixpkgs/commit/8432892fea2c6a60e4243490a151115902dddb70) | `` sampo: 0.20.0 -> 0.21.0 ``                                                                   |
| [`6c6a3788`](https://github.com/NixOS/nixpkgs/commit/6c6a3788df46ff40f8cc7133ae096dd68bcd018c) | `` dwproton-bin: refactor overrideAttrs ``                                                      |
| [`ed8b6226`](https://github.com/NixOS/nixpkgs/commit/ed8b6226df40e4fb0243a31f9a60807956619e3c) | `` proton-ge-bin: add support for aarch64-linux ``                                              |
| [`2fec8221`](https://github.com/NixOS/nixpkgs/commit/2fec82210956c0ddb8158c646cdb687c0b859000) | `` proton-ge-bin: GE-Proton11-3 -> GE-Proton11-5 ``                                             |
| [`692608a4`](https://github.com/NixOS/nixpkgs/commit/692608a4d07247bfa30ddb8c411699e73f79b737) | `` devin-desktop: 3.7.25 -> 3.8.20 ``                                                           |
| [`274d768f`](https://github.com/NixOS/nixpkgs/commit/274d768fe4247f30f280df8828764c2fecd459be) | `` libretro.beetle-gba: 0-unstable-2026-04-20 -> 0-unstable-2026-08-23 ``                       |
| [`588fb06a`](https://github.com/NixOS/nixpkgs/commit/588fb06a7c4346f67d9052e27e67466c4e41f791) | `` pi-coding-agent: 0.84.3 -> 0.84.4 ``                                                         |
| [`c1996c29`](https://github.com/NixOS/nixpkgs/commit/c1996c29ac6ca6c0590e919c79539d9632b4c58b) | `` sextractor: init at 2.28.2-unstable-2026-03-11 ``                                            |
| [`9f6d2923`](https://github.com/NixOS/nixpkgs/commit/9f6d29236f911661b3d1a0a611d87b9fb189603c) | `` python3Packages.wyoming: 1.10.0 -> 1.10.2 ``                                                 |
| [`aca76ce3`](https://github.com/NixOS/nixpkgs/commit/aca76ce308eef754f4f2db4e80f8cd1ddf264eaa) | `` python3Packages.boto3-stubs: 1.43.82 -> 1.43.83 ``                                           |
| [`2e6857e2`](https://github.com/NixOS/nixpkgs/commit/2e6857e2efa40decf9f0e90eb33a3b56e338a654) | `` python3Packages.mypy-boto3-healthlake: 1.43.67 -> 1.43.83 ``                                 |
| [`d90d3034`](https://github.com/NixOS/nixpkgs/commit/d90d303473ab0f11da145be85428b97138652d08) | `` python3Packages.mypy-boto3-ecs: 1.43.65 -> 1.43.83 ``                                        |
| [`d770f454`](https://github.com/NixOS/nixpkgs/commit/d770f45472c5f45e2879b2e8b7e9eababe25f152) | `` python3Packages.mypy-boto3-cognito-idp: 1.43.82 -> 1.43.83 ``                                |
| [`e25118ae`](https://github.com/NixOS/nixpkgs/commit/e25118aea46b47619569bd9cd377d1123dc4bb72) | `` frigate: fix by overriding tokenizers ``                                                     |
| [`8de90b2e`](https://github.com/NixOS/nixpkgs/commit/8de90b2e4ded653efc78fe18234cc699902050f0) | `` python3Packages.sentence-transformers: skip failing tests ``                                 |
| [`d3f92a5b`](https://github.com/NixOS/nixpkgs/commit/d3f92a5bb7f67e877841ebe5ab8a6eea6b47080c) | `` Reapply "huggingface: update" ``                                                             |
| [`a4b581c8`](https://github.com/NixOS/nixpkgs/commit/a4b581c85d3be48c9f18c0847b999bb6014f7e1b) | `` httrack: fix license ``                                                                      |
| [`95fb1437`](https://github.com/NixOS/nixpkgs/commit/95fb1437657b5efa975f3fe301d81eec098ea6b6) | `` httrack: add changelog to meta ``                                                            |
| [`b9be16a6`](https://github.com/NixOS/nixpkgs/commit/b9be16a68feaccb211049913a31e70c471bf58be) | `` python3Packages.plac: modernize ``                                                           |
| [`5bda016e`](https://github.com/NixOS/nixpkgs/commit/5bda016e3c80358132b24424ed69e7ecd8cf039f) | `` python3Packages.midea-local: 7.0.0 -> 10.1.0 ``                                              |
| [`e268b828`](https://github.com/NixOS/nixpkgs/commit/e268b828fd051c2afb0830169bffdf3c36e2a392) | `` python3Packages.spsdk: 3.9.0 -> 3.11.0 ``                                                    |
| [`2708a629`](https://github.com/NixOS/nixpkgs/commit/2708a629f02a1ec2cef9ae8d5c493e28fb1e5eee) | `` python3Packages.spsdk-mcu-link: 0.6.6 -> 0.6.14 ``                                           |
| [`5526c347`](https://github.com/NixOS/nixpkgs/commit/5526c3471d429b7174b33dc722eb194634278690) | `` python3Packages.midea-local: migrate to finalAttrs ``                                        |
| [`3fb5f408`](https://github.com/NixOS/nixpkgs/commit/3fb5f408e0c5cc81334c9f2ba7fc539d233af691) | `` python3Packages.midea-local: add pythonImportsCheck ``                                       |
| [`4eb88542`](https://github.com/NixOS/nixpkgs/commit/4eb88542066f42f4267be9f3f11ebb2046279fa6) | `` python3Packages.kivy: fix builds on `aarch64-darwin` ``                                      |
| [`82bc7176`](https://github.com/NixOS/nixpkgs/commit/82bc7176ca33cdeaf5c35c911d38306c9420727a) | `` linuxPackages.wireguard: remove ``                                                           |
| [`b4a0395c`](https://github.com/NixOS/nixpkgs/commit/b4a0395c10f755e79c0c04a700546f49ec8ddef2) | `` python3Packages.niquests: 3.21.0 -> 3.21.1 ``                                                |
| [`7a1362dd`](https://github.com/NixOS/nixpkgs/commit/7a1362dd36c3b6ea55a80944c6913722e11b85dd) | `` scenic-view: mark broken on aarch64-linux ``                                                 |
| [`1a26e736`](https://github.com/NixOS/nixpkgs/commit/1a26e736bc3ae75737ea0730ef809b24e2aa9684) | `` scenic-view: use Gradle 8 ``                                                                 |
| [`6692e97b`](https://github.com/NixOS/nixpkgs/commit/6692e97b527028d9462712504d50d5699f06e4d4) | `` fable: 5.13.0 -> 5.15.0 ``                                                                   |
| [`37333b7f`](https://github.com/NixOS/nixpkgs/commit/37333b7f45213c8b062427874e8fd32886a540d8) | `` python3Packages.python-didl-lite: 1.5.0 -> 1.5.1 ``                                          |
| [`87e4c698`](https://github.com/NixOS/nixpkgs/commit/87e4c6982f32aa0ba3afe77d9fb77ff8cd33db1b) | `` linuxPackages.e1000e: remove ``                                                              |
| [`6a60cd3f`](https://github.com/NixOS/nixpkgs/commit/6a60cd3f3148c9ca304f9ae6f847da1165c358ab) | `` adscan: 11.1.0 -> 11.2.0 ``                                                                  |
| [`525d82ff`](https://github.com/NixOS/nixpkgs/commit/525d82fff856a733e0174f31aca2d090ece76978) | `` nmap: set meta.mainProgram ``                                                                |
| [`d8576b0a`](https://github.com/NixOS/nixpkgs/commit/d8576b0a63f5f6ada6fabed35cc971d89af5b509) | `` tilemaker: 3.1.0 -> 3.2.0 ``                                                                 |
| [`afbadc1b`](https://github.com/NixOS/nixpkgs/commit/afbadc1bd4143bf7dd56a68274a101ca1d5e1255) | `` xearth: mark as `unfreeRedistributable` ``                                                   |
| [`a48853c7`](https://github.com/NixOS/nixpkgs/commit/a48853c72c137c36c8dc964778e634a4667f0949) | `` terraform-providers.gitlabhq_gitlab: 19.2.1 -> 19.3.0 ``                                     |
| [`cde48b19`](https://github.com/NixOS/nixpkgs/commit/cde48b193b33c3cb4405a6b12e57ba8235134b09) | `` discordchatexporter-desktop: 2.47.3 -> 2.48 ``                                               |
| [`c6420c6a`](https://github.com/NixOS/nixpkgs/commit/c6420c6aec3c4d5701e33f7827552ed08f1e6e7f) | `` home-assistant-matter-hub: 2.0.55 -> 2.0.56 ``                                               |
| [`d9b724e7`](https://github.com/NixOS/nixpkgs/commit/d9b724e7c2524886c536786877e0bfa97c1e8b4c) | `` libvgm: Drop OPNA2608 from meta.maintainers ``                                               |
| [`dc96c72a`](https://github.com/NixOS/nixpkgs/commit/dc96c72a297b1a93a84839f84f9c367db6ba8d45) | `` rqbit: 9.0.0 -> 9.0.1 ``                                                                     |
| [`155f289e`](https://github.com/NixOS/nixpkgs/commit/155f289efcb7b1dbcd0dc2c2894418a673fc9d94) | `` terraform-providers.metio_migadu: 2026.8.20 -> 2026.8.27 ``                                  |
| [`e0b1c6b8`](https://github.com/NixOS/nixpkgs/commit/e0b1c6b86eab46539414906adc8cba5f07195e4d) | `` python3Packages.pycrdt: 0.14.3 -> 0.14.4 ``                                                  |
| [`5812d9a5`](https://github.com/NixOS/nixpkgs/commit/5812d9a571b5aa1139dd8aadc420f03e4fb17c61) | `` subtitleedit: drop ``                                                                        |
| [`8e1a8326`](https://github.com/NixOS/nixpkgs/commit/8e1a83260f127f116ede92a2ce226988c8d8d1cc) | `` guile-xcb: build with guile 3 ``                                                             |
| [`a538016d`](https://github.com/NixOS/nixpkgs/commit/a538016db9f656e3f549a34dc3e16e11dcf65c9f) | `` python3Packages.ha-mcp: 8.3.0 -> 8.4.0 ``                                                    |
| [`2785be45`](https://github.com/NixOS/nixpkgs/commit/2785be45617da071e070c8a06063660c7bd22506) | `` fetchmail: 6.6.6 -> 6.6.7 ``                                                                 |
| [`8531f22a`](https://github.com/NixOS/nixpkgs/commit/8531f22ac784a1c26f5413a0caccfaf84244ca6d) | `` g-wrap: build with guile 3 ``                                                                |
| [`00f7780e`](https://github.com/NixOS/nixpkgs/commit/00f7780e48541590c8fc302a60dec7c0bd48bf32) | `` x42-avldrums: 0.7.4 -> 0.7.5 ``                                                              |
| [`430bcb21`](https://github.com/NixOS/nixpkgs/commit/430bcb2172b2a0df5730bb9b707a0158a82d0bb7) | `` x42-plugins: 20260420 -> 20260829 ``                                                         |
| [`8adaeed1`](https://github.com/NixOS/nixpkgs/commit/8adaeed1e84023925d13eafb1c24f456b88a240b) | `` liquidwar: build with guile 3 ``                                                             |
| [`8d904ff4`](https://github.com/NixOS/nixpkgs/commit/8d904ff420b93570b5155360dda83a8043a40041) | `` bbot: adjust changelog URL ``                                                                |
| [`e1886742`](https://github.com/NixOS/nixpkgs/commit/e1886742f2bc4c45131a6f37b54cc69d68694978) | `` pyroscope: 2.2.1 -> 2.3.0 ``                                                                 |
| [`84dca671`](https://github.com/NixOS/nixpkgs/commit/84dca671ee5c627271aa6b165292e955349968e2) | `` all-the-package-names: 2.0.2538 -> 2.0.2547 ``                                               |
| [`681b64be`](https://github.com/NixOS/nixpkgs/commit/681b64beb5e878fb0cbf9c635256a23d9ac90a2e) | `` python3Packages.pyasn1-alt-modules: init at 0.4.10 ``                                        |
| [`b0522fbf`](https://github.com/NixOS/nixpkgs/commit/b0522fbf80e3c61dcf8b7925bf6cb96d69239ac7) | `` listenbrainz-mpd: 2.5.1 -> 2.6.0 ``                                                          |
| [`94b64c04`](https://github.com/NixOS/nixpkgs/commit/94b64c04998c06629ce3081b6ebfdd348c610311) | `` terraform-providers.rootlyhq_rootly: 5.18.2 -> 5.20.1 ``                                     |
| [`91e1f89f`](https://github.com/NixOS/nixpkgs/commit/91e1f89f491858b80327de18d0c3d27e4134d598) | `` sequoia-chameleon-gnupg: install man pages and shell completions ``                          |
| [`de0b9199`](https://github.com/NixOS/nixpkgs/commit/de0b9199b6db0d71845caa65bded56d9668db533) | `` yamlscript: 0.2.29 -> 0.2.32 ``                                                              |
| [`336c64eb`](https://github.com/NixOS/nixpkgs/commit/336c64eb8dca8f4a09ebf25c42b103b5caa45ab6) | `` hddtemp: enable strictDeps and structuredAttrs ``                                            |
| [`f95f5b2a`](https://github.com/NixOS/nixpkgs/commit/f95f5b2a4945018a05bf137d69cba01fa9d652a6) | `` nixos/tests/hddtemp: add NixOS integration test ``                                           |
| [`8d73224c`](https://github.com/NixOS/nixpkgs/commit/8d73224cbbf6755b445fd604e294bd5883d0c1ea) | `` signal-desktop: 8.24.0 -> 8.25.0 ``                                                          |
| [`dfa71130`](https://github.com/NixOS/nixpkgs/commit/dfa71130bb87fe5dbcb7b402b5a11b81da98c49e) | `` lact: 0.10.0 -> 0.10.1 ``                                                                    |
| [`11e4d006`](https://github.com/NixOS/nixpkgs/commit/11e4d00631e12fc6cf70f9f00b4b817015535fd1) | `` midisheetmusic: drop ``                                                                      |
| [`30e678ce`](https://github.com/NixOS/nixpkgs/commit/30e678cee174d531f566433e97204b3dbb710478) | `` ansi2html: 1.9.2 -> 1.9.3 ``                                                                 |
| [`b43bb9b8`](https://github.com/NixOS/nixpkgs/commit/b43bb9b83dff3cc96fea199f249a27a6c601df85) | `` rssguard: use default CMAKE_BUILD_TYPE ``                                                    |
| [`ee3fab7a`](https://github.com/NixOS/nixpkgs/commit/ee3fab7a9e598c49933857f6aa5e10b3f7309341) | `` flightgear: 2024.1.6 -> 2024.1.7 ``                                                          |
| [`853d2028`](https://github.com/NixOS/nixpkgs/commit/853d20289a584a096c22a49e49e89538aa36bbfd) | `` crush: 0.88.1 -> 0.91.2 ``                                                                   |
| [`cfc6da04`](https://github.com/NixOS/nixpkgs/commit/cfc6da0499834233e99e08070f8d906c954120a4) | `` chisel: 1.11.8 -> 1.12.0 ``                                                                  |
| [`c5c84dc6`](https://github.com/NixOS/nixpkgs/commit/c5c84dc622e8f370c02e6ca57a28d661dd721691) | `` man-pages: 6.18 -> 6.19 ``                                                                   |
| [`8fce393c`](https://github.com/NixOS/nixpkgs/commit/8fce393c9c8d7f30a4fd7958139d365bb6399054) | `` atmos: 1.226.0 -> 1.227.0 ``                                                                 |
| [`8e6958fd`](https://github.com/NixOS/nixpkgs/commit/8e6958fde7640663e7a320bc9669850639061769) | `` harlequin: 2.10.0 -> 2.12.0 ``                                                               |
| [`dd0012ff`](https://github.com/NixOS/nixpkgs/commit/dd0012ff332b4b756a2ee2869a3a21d77c9d5781) | `` python3Packages.tree-sitter-sql: cleanup, use release tarball to get the generated parser `` |
| [`db58b0ea`](https://github.com/NixOS/nixpkgs/commit/db58b0ea6013a8fd73acf640ae9419466a8b914d) | `` gitea: 1.27.2 -> 1.27.3 ``                                                                   |
| [`30b286ba`](https://github.com/NixOS/nixpkgs/commit/30b286baa9bda4b34dff80cb17b5bac5746e962d) | `` crossplane-cli: fix changelog URL ``                                                         |
| [`cde316bb`](https://github.com/NixOS/nixpkgs/commit/cde316bb97afdd072d7221997fff138fb4d138e2) | `` nurl: 0.4.0 -> 0.4.1 ``                                                                      |
| [`1cbbcddc`](https://github.com/NixOS/nixpkgs/commit/1cbbcddcf76c61e329ae85ccf20ee0c9bcfbac5a) | `` stirling-pdf: skip tests failing due to expired certs ``                                     |
| [`6f9e4b91`](https://github.com/NixOS/nixpkgs/commit/6f9e4b915311a7e593040821d800b82b6c5966a5) | `` envoy-bin: 1.39.0 -> 1.39.1 ``                                                               |
| [`3b633fee`](https://github.com/NixOS/nixpkgs/commit/3b633fee10274c41cfff11c15c49e51ac97d195e) | `` zellij-unwrapped: 0.45.0 -> 0.45.1 ``                                                        |
| [`f5b45802`](https://github.com/NixOS/nixpkgs/commit/f5b4580235c074db8aa217f68598dfe2581c3cca) | `` nextvi: 7.3 -> 7.4 ``                                                                        |
| [`99673f06`](https://github.com/NixOS/nixpkgs/commit/99673f06de8db04313964d7295b25140de8fe33a) | `` sideband: 2.0.0 -> 2.1.0 ``                                                                  |
| [`3d6b43f0`](https://github.com/NixOS/nixpkgs/commit/3d6b43f0b0c2c8c1688e2782162ee85a4e47eca2) | `` terraform-providers.okta_okta: 6.15.0 -> 7.0.0 ``                                            |
| [`1a4f94c6`](https://github.com/NixOS/nixpkgs/commit/1a4f94c630ea80a84958dbee386eb6709aecde52) | `` python3Packages.rns: 1.5.1 -> 1.5.2 ``                                                       |
| [`adf8f218`](https://github.com/NixOS/nixpkgs/commit/adf8f2189e8b707a5be84598314c0e1f71ba97f6) | `` arduino-cli: fix riscv64-linux build ``                                                      |
| [`cc9d03ca`](https://github.com/NixOS/nixpkgs/commit/cc9d03cac8ac5c74721afad05a79e61543b64209) | `` dwproton-bin: dwproton-11.0-11 -> dwproton-11.0-12 ``                                        |
| [`62390448`](https://github.com/NixOS/nixpkgs/commit/623904488774eae40a4758f74380017e40d5393c) | `` modprobed-db: 2.50 -> 2.51 ``                                                                |
| [`aa1528b3`](https://github.com/NixOS/nixpkgs/commit/aa1528b327dadc9d4b14c5fbf0c943ad0f2abd99) | `` nagiosPlugins.check_ssl_cert: 2.96.0 -> 2.103.1 ``                                           |
| [`8b625231`](https://github.com/NixOS/nixpkgs/commit/8b625231996b9d1f34240f0c8847cb3201af2cde) | `` niks3: 1.9.0 -> 1.10.0 ``                                                                    |
| [`a3a04caf`](https://github.com/NixOS/nixpkgs/commit/a3a04caff978954729a8a5f3c97d6741103da7a7) | `` python3Packages.streamcontroller-streamdeck: 0.2.0 -> 0.2.1 ``                               |
| [`e443d085`](https://github.com/NixOS/nixpkgs/commit/e443d08568701c374a2661b9274781214ade5810) | `` hunk: 0.19.0 -> 0.20.1 ``                                                                    |
| [`6b0f1a11`](https://github.com/NixOS/nixpkgs/commit/6b0f1a114d27b54916fed9d0f8f75ccf7af29a35) | `` vimPlugins.range-highlight-nvim: unused dependency ``                                        |
| [`05a4593a`](https://github.com/NixOS/nixpkgs/commit/05a4593a9d61d858db177a9760ddbfa6ce6ae350) | `` wvdial: fix invalid unstable version scheme ``                                               |
| [`7f0ec603`](https://github.com/NixOS/nixpkgs/commit/7f0ec6030891671f651c6cbb5ca3e409f6a31d0f) | `` xfs-undelete: fix invalid unstable version scheme ``                                         |
| [`c8aee94d`](https://github.com/NixOS/nixpkgs/commit/c8aee94da9699dd5e90bdc54e332dac09cbd617e) | `` dprint: 0.55.2 -> 0.56.1 ``                                                                  |
| [`c5f04198`](https://github.com/NixOS/nixpkgs/commit/c5f04198650fa8e71265d67bf38123f0a10a7a52) | `` bbot: 3.0.1 -> 3.0.2 ``                                                                      |
| [`94632c29`](https://github.com/NixOS/nixpkgs/commit/94632c294d49a25aa6118e6b31b2a688ce2b144a) | `` mirrord: 3.249.0 -> 3.251.0 ``                                                               |
| [`5ebc3e46`](https://github.com/NixOS/nixpkgs/commit/5ebc3e4653d3014886f73e1ea9fa01527c5f739f) | `` aquamarine: 0.14.0 -> 0.15.0 ``                                                              |
| [`f69fec58`](https://github.com/NixOS/nixpkgs/commit/f69fec58dae1ae9c24e641e366a03f28ff5d41f3) | `` python3Packages.deepspeed: fix on darwin ``                                                  |
| [`cedeaa03`](https://github.com/NixOS/nixpkgs/commit/cedeaa030b5b68a7b6ac66ec3f3fc4374cd8fbfc) | `` buzz-cli: init at 0.1.0-unstable-2026-08-27 ``                                               |
| [`96b1c047`](https://github.com/NixOS/nixpkgs/commit/96b1c0476727365ba8e33b2441ab39becfb52bba) | `` Revert "nixos/sd-image: use lsblk -npo PARTN to identify partition for sd-card expansion" `` |
| [`52f02f66`](https://github.com/NixOS/nixpkgs/commit/52f02f6652047a3d0e32a5713a4fbcb2c42c5b60) | `` fermyon-spin: remove unused dependencies on darwin ``                                        |
| [`ad4cab6c`](https://github.com/NixOS/nixpkgs/commit/ad4cab6c5134c657f76db19184cfb72ede82335c) | `` fermyon-spin: 4.0.2 -> 4.1.0 ``                                                              |
| [`4e175336`](https://github.com/NixOS/nixpkgs/commit/4e175336dd6f19a4ae3863471571c88368deff51) | `` menyoki: 1.7.0 -> 1.8.0 ``                                                                   |
| [`116fd29d`](https://github.com/NixOS/nixpkgs/commit/116fd29dec36691eb1fa9b8601259d742e785f5b) | `` sdl_gamecontrollerdb: 0-unstable-2026-08-12 -> 0-unstable-2026-08-29 ``                      |
| [`ad38c168`](https://github.com/NixOS/nixpkgs/commit/ad38c1687f8598ed5baa2c990317cc798cc99edf) | `` speech-to-phrase: init at 1.4.3 ``                                                           |
| [`4206f605`](https://github.com/NixOS/nixpkgs/commit/4206f60585a4e5027a1e7c58f8e8a680c918e527) | `` kaldi: add online2-cli-nnet3-decode-faster cli ``                                            |
| [`683bc131`](https://github.com/NixOS/nixpkgs/commit/683bc13133433a200e5405605c3c5dd8574824a5) | `` phonetisaurus: 0.9.1 -> 0.9.1-unstable-2026-01-05, fix build by switching to kaldi fork ``   |
| [`9ae078d2`](https://github.com/NixOS/nixpkgs/commit/9ae078d29f22f32e19ae8d38a428e21e6635e97c) | `` cdk8s-cli: 2.207.53 -> 2.207.57 ``                                                           |
| [`d31e13c3`](https://github.com/NixOS/nixpkgs/commit/d31e13c3ffa0593987316b9c4cb61d82b5c600a7) | `` scanservjs: 3.1.0 -> 3.3.0 ``                                                                |
| [`31987d9a`](https://github.com/NixOS/nixpkgs/commit/31987d9a0215e6330431cb18ca65647f889b825a) | `` os-agent: 1.11.0 -> 1.13.0 ``                                                                |
| [`2384b261`](https://github.com/NixOS/nixpkgs/commit/2384b261c38b6f1ae6a394a85625345485d8d693) | `` azurefox: init at 1.5.0 ``                                                                   |
| [`fb36d759`](https://github.com/NixOS/nixpkgs/commit/fb36d759e87510596731d9902ac09499b948c4ed) | `` python3Packages.azure-mgmt-resource-subscriptions: init at 1.0.0 ``                          |
| [`759f461b`](https://github.com/NixOS/nixpkgs/commit/759f461bdb709fdb3fac3548a3073019c29f05d7) | `` python3Packages.azure-mgmt-resource-deployments: migrate to finalAttrs ``                    |
| [`c7496b9d`](https://github.com/NixOS/nixpkgs/commit/c7496b9dfacb3b0ae6328c7be687d729490183db) | `` python3Packages.deepspeed: skip failing tests on aarch64-linux ``                            |
| [`50542cb1`](https://github.com/NixOS/nixpkgs/commit/50542cb1f054fd39ab5be2fbf34a77d03ec2da05) | `` python3Packages.nptyping: drop ``                                                            |
| [`f770abf7`](https://github.com/NixOS/nixpkgs/commit/f770abf715c938193a693bfe579a9d5a38cd25fc) | `` ddnet: 19.8.3 -> 20.0 ``                                                                     |
| [`fc9d1863`](https://github.com/NixOS/nixpkgs/commit/fc9d186318da4ceeaac130a00a2f85b1c7c63ac5) | `` seagoat: fix build by relaxing deepmerge ``                                                  |
| [`e6511611`](https://github.com/NixOS/nixpkgs/commit/e651161184c81b265a1bcd74cbdc0026ac1deb48) | `` tuple: init at 3.2.0 ``                                                                      |
| [`b6fec815`](https://github.com/NixOS/nixpkgs/commit/b6fec8150766aa60297c016bf5151ca171e4f00f) | `` python3Packages.brainflow: rm unused dep `nptyping`, unbreak ``                              |
| [`551b7413`](https://github.com/NixOS/nixpkgs/commit/551b7413c374392280b832a8fcd65ed853f84d40) | `` starlark: 0-unstable-2026-07-08 -> 0-unstable-2026-08-28 ``                                  |
| [`45629a5c`](https://github.com/NixOS/nixpkgs/commit/45629a5c95fdc7b0eb8070b598acae5d9bf3932b) | `` nagiosPlugins.check_interfaces: fix compiler error ``                                        |
| [`a55e34b6`](https://github.com/NixOS/nixpkgs/commit/a55e34b627a86055204bd609a5d8ab4e700a2aea) | `` tauon: set phazor pipewire include paths ``                                                  |
| [`a56eb708`](https://github.com/NixOS/nixpkgs/commit/a56eb7083159a3f110fda51b31c5fcd11f1228c2) | `` tauon: 11.1.1 -> 12.0.0 ``                                                                   |
| [`f7f3445a`](https://github.com/NixOS/nixpkgs/commit/f7f3445af3647656972d6dbee20f971d89d0c981) | `` python3Packages.wassima: 2.1.3 -> 2.1.4 ``                                                   |
| [`d9348f9d`](https://github.com/NixOS/nixpkgs/commit/d9348f9d1dfa1af59318c1c6e5fb2c7b96bca7e2) | `` microsoft-edge: fix graphics libs error ``                                                   |
| [`10ee64c5`](https://github.com/NixOS/nixpkgs/commit/10ee64c5809a56c0bcdf379b4baab6c0847f6c4f) | `` dcp: 0.25.12 -> 0.25.13 ``                                                                   |
| [`262dd08b`](https://github.com/NixOS/nixpkgs/commit/262dd08b3ece2028a9f9392336be1f6967ed209d) | `` msedgedriver: 150.0.4078.105 -> 152.0.4191.53 ``                                             |
| [`1a1db406`](https://github.com/NixOS/nixpkgs/commit/1a1db40610c0d2e49c73cfc821c1c8a1a42c4c23) | `` microsoft-edge: 150.0.4078.105 -> 152.0.4191.53 ``                                           |
| [`9b44a6a5`](https://github.com/NixOS/nixpkgs/commit/9b44a6a503a27cd6df828b4a8e3d59bd16cabc8e) | `` rgrc: 0.6.20 -> 0.6.30 ``                                                                    |
| [`78d301ad`](https://github.com/NixOS/nixpkgs/commit/78d301adc6b5e7b68ba0bbb0747f4f48dd4b2dd1) | `` nixosTests.switchTest: split into parts to bound evaluation memory ``                        |
| [`0c5b5bc3`](https://github.com/NixOS/nixpkgs/commit/0c5b5bc39760b16549eada709a3588b61551ad57) | `` python3Packages.peakrdl-rust: 0.7.3 -> 0.7.4 ``                                              |
| [`86f565ed`](https://github.com/NixOS/nixpkgs/commit/86f565ed9c0a342bbe87a91fdb4121a5d095a37c) | `` atril: 1.28.6 -> 1.28.7 ``                                                                   |
| [`534e59b7`](https://github.com/NixOS/nixpkgs/commit/534e59b7a0914d8aa44144a1747a280f90305067) | `` linecast: init at 2.1.0 ``                                                                   |
| [`276bb420`](https://github.com/NixOS/nixpkgs/commit/276bb4203a9c06a2c5381c0f9b22b5e684b0400b) | `` aws-cdk-cli: 2.1138.0 -> 2.1139.0 ``                                                         |
| [`04cd0460`](https://github.com/NixOS/nixpkgs/commit/04cd04600b5e0c430c5464c43f9f1106e066c2cc) | `` terraform-providers.cloudflare_cloudflare: 5.23.0 -> 5.24.0 ``                               |
| [`97fb76a2`](https://github.com/NixOS/nixpkgs/commit/97fb76a2cc7c875bdc9ed486bda19ab2977c154d) | `` untrunc-anthwlock: 0-unstable-2026-06-05 -> 0-unstable-2026-08-20 ``                         |
| [`10ca1515`](https://github.com/NixOS/nixpkgs/commit/10ca1515528507b185033bddb47ca2a2b114b210) | `` aseprite: 1.3.18.2 -> 1.3.18.3 ``                                                            |
| [`e905be28`](https://github.com/NixOS/nixpkgs/commit/e905be285cde4d406cb6c80592e7fac78f430860) | `` cargo-feature-combinations: 0.5.0 -> 0.7.0 ``                                                |
| [`b6876cca`](https://github.com/NixOS/nixpkgs/commit/b6876ccafbd87fc8166a09c8bc735ae9c8d5348e) | `` numen: 0.4.1 -> 0.5.1 ``                                                                     |
| [`8928bb7a`](https://github.com/NixOS/nixpkgs/commit/8928bb7aefb57f2a1eafc2ae18c9c0ef1c563f8c) | `` numen: disable tests on darwin ``                                                            |
| [`13f38d2c`](https://github.com/NixOS/nixpkgs/commit/13f38d2c819447f9ec7dcf4a4cd1e43e21db8fe0) | `` uzdoom: cleanup ``                                                                           |
| [`a949a13a`](https://github.com/NixOS/nixpkgs/commit/a949a13a32d2c1d1a802e05e995928193f251a82) | `` python3Packages.vllm: set mainProgram ``                                                     |
| [`da6fd202`](https://github.com/NixOS/nixpkgs/commit/da6fd2020255df9faf27d7d70ef6b664a6138a7f) | `` uzdoom: modernize ``                                                                         |
| [`73789b8c`](https://github.com/NixOS/nixpkgs/commit/73789b8cb5351d6552d2b74afe13914ec8b8452f) | `` uzdoom: change meta fields ``                                                                |
| [`1046b249`](https://github.com/NixOS/nixpkgs/commit/1046b24935abc7e83a166325865d2b5cf1fc2599) | `` uzdoom: 4.14.3 -> 5.0.0 ``                                                                   |
| [`eb723b7c`](https://github.com/NixOS/nixpkgs/commit/eb723b7c3dbd86b7511dc6dc286337db0fe430a3) | `` spotify: (linux) 1.2.92.147.g5b8f9367 -> 1.2.95.453.g0eeebbed ``                             |
| [`429c4e96`](https://github.com/NixOS/nixpkgs/commit/429c4e9600b834d988fa820618670cc9177b7631) | `` spotify: (darwin) 1.2.94.583 -> 1.2.98.301 ``                                                |
| [`47660eb4`](https://github.com/NixOS/nixpkgs/commit/47660eb40d46172bdd5e10e350844731ae09822a) | `` groonga: 16.0.9 -> 16.1.0 ``                                                                 |
| [`2112e7c3`](https://github.com/NixOS/nixpkgs/commit/2112e7c3208770824392c3b77451f0af0d0b9415) | `` python3Packages.ocrmypdf: 17.10.0 -> 17.11.0 ``                                              |
| [`58ce81ca`](https://github.com/NixOS/nixpkgs/commit/58ce81ca2d8eeb2864ced2bdf59c7787aaba055c) | `` freeipmi: 1.6.18 -> 1.6.19 ``                                                                |
| [`986c38a7`](https://github.com/NixOS/nixpkgs/commit/986c38a792375bf50f723ae891c8f6f177cf4a43) | `` airwindows-lv2: 38.0 -> 40.0 ``                                                              |
| [`622f9b32`](https://github.com/NixOS/nixpkgs/commit/622f9b32a385c0eaadcfbb8d8928bb85ae692b97) | `` omniwm: init at 0.6.3 ``                                                                     |
| [`eee7a283`](https://github.com/NixOS/nixpkgs/commit/eee7a28381472e54ce43627859fdbed3d89bf324) | `` thunderkittens: 0-unstable-2026-08-18 -> 0-unstable-2026-08-27 ``                            |
| [`4bb93356`](https://github.com/NixOS/nixpkgs/commit/4bb9335662846b0bfd83bd9904dac2d8b8590c25) | `` terraform-providers.pagerduty_pagerduty: 3.35.0 -> 3.36.0 ``                                 |
| [`ee28416b`](https://github.com/NixOS/nixpkgs/commit/ee28416b3ebdc704a119214542bf6383fc45901a) | `` php84: 8.4.24 -> 8.4.25 ``                                                                   |
| [`e1514245`](https://github.com/NixOS/nixpkgs/commit/e15142453b5b081b0b0bde291cf9abc4f3b2850e) | `` python3Packages.jupyter-server-ydoc: 3.0.0 -> 3.0.2 ``                                       |
| [`4cf9b0ae`](https://github.com/NixOS/nixpkgs/commit/4cf9b0aed347f5d256d046a418b402b045053612) | `` nixos/kmscon: disable libseat by default ``                                                  |
| [`55e3dee9`](https://github.com/NixOS/nixpkgs/commit/55e3dee99caeae9013ba6de2f6633fada81b31d2) | `` kmscon: 10.0.0 -> 10.0.2 ``                                                                  |
| [`ace30f03`](https://github.com/NixOS/nixpkgs/commit/ace30f030eb370247768d5def7b8ed39fbef17bd) | `` oh-my-posh: 30.6.5 -> 30.9.0 ``                                                              |
| [`c4e6a829`](https://github.com/NixOS/nixpkgs/commit/c4e6a8290f661604e0c04f8cd29a57638a3c624a) | `` cook-cli: 0.33.1 -> 0.34.0 ``                                                                |
| [`041511bb`](https://github.com/NixOS/nixpkgs/commit/041511bbc6549b0a422a03872d953af9ce20238e) | `` python3Packages.claude-agent-sdk: 0.2.147 -> 0.2.148 ``                                      |
| [`65024fea`](https://github.com/NixOS/nixpkgs/commit/65024fea488b9b185a977f0018f895c33075f098) | `` opengrok: 1.14.16 -> 1.14.17 ``                                                              |
| [`b28f6d8e`](https://github.com/NixOS/nixpkgs/commit/b28f6d8e239594c187e5b8b8eb8d8ff50b56dd96) | `` exploitdb: 2026-08-26 -> 2026-08-29 ``                                                       |
| [`da421d12`](https://github.com/NixOS/nixpkgs/commit/da421d1225bb1b28e40ea8d6f5853251f5552f1e) | `` terraform: 1.15.9 -> 1.16.0 ``                                                               |
| [`e7ead549`](https://github.com/NixOS/nixpkgs/commit/e7ead5493b65990b0e5f68835174521148ab1210) | `` url-parser: 2.1.21 -> 2.1.22 ``                                                              |
| [`2ad83353`](https://github.com/NixOS/nixpkgs/commit/2ad833530c1d1fdddec47d9b43ac2e96729454c4) | `` python3Packages.spatialmath-python: 1.1.16 -> 1.1.17 ``                                      |
| [`f6736dce`](https://github.com/NixOS/nixpkgs/commit/f6736dce3e642f50b3c505d051aac54e7fb600a8) | `` python3Packages.python-arango: modernize ``                                                  |
| [`9318d701`](https://github.com/NixOS/nixpkgs/commit/9318d7010041506a5483d33d07c4f3380367ca62) | `` xlights: 2026.15 -> 2026.16 ``                                                               |
| [`e9efe19d`](https://github.com/NixOS/nixpkgs/commit/e9efe19daa40d10e70138788f2bd8a3bf5115f32) | `` yutto: 2.3.0 -> 2.3.1 ``                                                                     |
| [`35b104b4`](https://github.com/NixOS/nixpkgs/commit/35b104b45a4f9c8acd7f1e589bf0da1805f40cca) | `` python3Packages.cmaes: migrate to finalAttrs ``                                              |
| [`2dc45f64`](https://github.com/NixOS/nixpkgs/commit/2dc45f64b994b43eae802dfc7ed3396e7fd456e5) | `` python314Packages.e2b: 2.39.1 -> 2.46.1 ``                                                   |
| [`8bd621f5`](https://github.com/NixOS/nixpkgs/commit/8bd621f5becb8d4748e5ce6404861883efd08a45) | `` python3Packages.urllib3-future: migrate to finalAttrs ``                                     |
| [`b7105abe`](https://github.com/NixOS/nixpkgs/commit/b7105abed65624e2701af4740ae39d338d96a860) | `` pinta: fix text tool on linux by adding pango dependency ``                                  |
| [`34afc93a`](https://github.com/NixOS/nixpkgs/commit/34afc93a5b5359e1ac6ba779a04bbab0369849f8) | `` python3Packages.pyprobeplus: migrate to finalAttrs ``                                        |
| [`1b085e84`](https://github.com/NixOS/nixpkgs/commit/1b085e84063ec958dfe0f343f7dc9ffca1c201c9) | `` python3Packages.groq: migrate to finalAttrs ``                                               |
| [`b8a3a7e0`](https://github.com/NixOS/nixpkgs/commit/b8a3a7e0a94169ede56e0e80a8ce008887bcae85) | `` neocmakelsp: 0.11.0 -> 0.11.1 ``                                                             |
| [`fa8cfb80`](https://github.com/NixOS/nixpkgs/commit/fa8cfb807a81f01962ebb7f5e0e9fb454f494d50) | `` python3Packages.iamdata: 0.1.202608271 -> 0.1.202608291 ``                                   |
| [`90c0f0d1`](https://github.com/NixOS/nixpkgs/commit/90c0f0d188375866e2b94fee4e05d87308b83ba1) | `` introspectre: init at 1.13.5 ``                                                              |
| [`eb9e2ac8`](https://github.com/NixOS/nixpkgs/commit/eb9e2ac8759f5825604c6996406774e54e781ca5) | `` gitnr: 0.3.0 -> 0.3.1 ``                                                                     |
| [`c6786e54`](https://github.com/NixOS/nixpkgs/commit/c6786e54865e527cd86d17171c3311056132c9da) | `` giza: 1.5.0 -> 2.0.0 ``                                                                      |

*... and 4744 more commits (truncated)*